### PR TITLE
Only adjust X11 settings if the configuration file exists.

### DIFF
--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -35,7 +35,10 @@ make
 
 %post
 ldconfig
-grep -Fxq "use-oidc-agent" /etc/X11/Xsession.options || echo "use-oidc-agent" >> /etc/X11/Xsession.options
+
+if [ -f /etc/X11/Xsession.options ]; then
+  grep -Fxq "use-oidc-agent" /etc/X11/Xsession.options || echo "use-oidc-agent" >> /etc/X11/Xsession.options
+fi
 
 %postun
 ldconfig


### PR DESCRIPTION
Avoids a scary stderr message when installing the RPM.