### PR TITLE
Set the specific OWASP dependency report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             }
             post {
                 always {
-                    OWASPDependencyCheckPublish()
+                    OWASPDependencyCheckPublish(report='**/dependency-check-report.xml')
                     HTMLReport(
                         "$WORKSPACE/oidc-agent",
                         'dependency-check-report.html',


### PR DESCRIPTION
OWASP check is failing to parse `dependency-check-junit.xml` report. For the time being we just need the `dependency-check-report.xml`, but this has to be specified as an argument.