### PR TITLE
Reduce oidc-add -l output

### DIFF
--- a/src/utils/commonFeatures.c
+++ b/src/utils/commonFeatures.c
@@ -13,7 +13,7 @@ void common_handleListConfiguredAccountConfigs() {
   list_mergeSort(list, (int (*)(const void*, const void*))compareFilesByName);
   char* str = listToDelimitedString(list, '\n');
   list_destroy(list);
-  printStdout("The following account configurations are usable: \n%s\n", str);
+  printStdout("%s\n", str);
   secFree(str);
 }
 

--- a/src/utils/file_io/fileUtils.c
+++ b/src/utils/file_io/fileUtils.c
@@ -46,7 +46,7 @@ list_t* getFileListForDirIf(const char* dirname,
     list->free   = (void (*)(void*)) & _secFree;
     list->match  = (matchFunction)strequal;
     while ((ent = readdir(dir)) != NULL) {
-      if (!strequal(ent->d_name, ".") && !strequal(ent->d_name, "..")) {
+      if (ent->d_name[0] != '.') {
 #ifdef _DIRENT_HAVE_DTYPE
         if (ent->d_type == DT_REG) {
 #endif


### PR DESCRIPTION
I'm sorry I only caught this shortly after you released 3.3.0.

This PR removes all "." files from the ssh-add -l list, because oidc-keychain puts a ".keychain" directory in the oidc-agent config directory.  It also eliminates the stdout explanatory line from ssh-add -l, because that gets in the way of parsing the output by script.