### PR TITLE
Generate oidc-agent.spec from oidc-agent.spec.in

### DIFF
--- a/rpm/oidc-agent.spec.in
+++ b/rpm/oidc-agent.spec.in
@@ -85,5 +85,3 @@ make install BIN_PATH=${RPM_BUILD_ROOT}/usr BIN_AFTER_INST_PATH=/usr MAN_PATH=${
 #%doc
 
 %changelog
-* Fri Oct 11 2019 Diego Davila <didavila@ucsd.edu> - 3.2.7
-- Changed the Source0, Version and Release tags to accommodate the osg build process

--- a/rpm/oidc-agent.spec.in
+++ b/rpm/oidc-agent.spec.in
@@ -1,5 +1,5 @@
 Name: oidc-agent
-Version: 3.3.1
+Version: @VERSION@
 Release: 1%{?dist}
 Summary: Commandline tool for obtaining OpenID Connect access tokens on the commandline
 Group: Misc


### PR DESCRIPTION
Addresses issue #249.   Also splits the rpm make target into a part that requires root (preparerpm) and another part that does not require root (buildrpm) in case somebody wants to build an rpm as an unprivileged user.

Note that after this you will need to remember to (1) edit rpm/oidc-agent.spec.in instead of rpm/oidc-agent.spec whenever you need to change the rpm spec and to (2) git commit the update to rpm/oidc-agent.spec after changing VERSION in the Makefile and building the rpm.  Make the latter part of the release procedure.