### PR TITLE
libsodium: use .so instead of .a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ ifndef MAC_OS
 PREFIX                    ?=
 BIN_PATH             			?=$(PREFIX)/usr# /bin is appended later
 BIN_AFTER_INST_PATH				?=$(BIN_PATH)# needed for debian package and desktop file exec
-LIB_PATH 	           			?=$(PREFIX)/usr/lib64
-LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib64
+LIB_PATH 	           			?=$(PREFIX)/usr/lib64/oidc-agent
+LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib64/oidc-agent
 INCLUDE_PATH         			?=$(PREFIX)/usr/include
 MAN_PATH             			?=$(PREFIX)/usr/share/man
 CONFIG_PATH          			?=$(PREFIX)/etc

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,9 @@ ifndef MAC_OS
 PREFIX                    ?=
 BIN_PATH             			?=$(PREFIX)/usr# /bin is appended later
 BIN_AFTER_INST_PATH				?=$(BIN_PATH)# needed for debian package and desktop file exec
-LIB_PATH 	           			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
-LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
-INCLUDE_PATH         			?=$(PREFIX)/usr/include/x86_64-linux-gnu
+LIB_PATH 	           			?=$(PREFIX)/usr/lib64
+LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib64
+INCLUDE_PATH         			?=$(PREFIX)/usr/include
 MAN_PATH             			?=$(PREFIX)/usr/share/man
 CONFIG_PATH          			?=$(PREFIX)/etc
 BASH_COMPLETION_PATH 			?=$(PREFIX)/usr/share/bash-completion/completions

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ BIN_AFTER_INST_PATH				?=$(BIN_PATH)# needed for debian package and desktop file
 LIB_PATH 	           			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
 LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
 INCLUDE_PATH         			?=$(PREFIX)/usr/include/x86_64-linux-gnu
-endif
 MAN_PATH             			?=$(PREFIX)/usr/share/man
 CONFIG_PATH          			?=$(PREFIX)/etc
 BASH_COMPLETION_PATH 			?=$(PREFIX)/usr/share/bash-completion/completions

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,19 @@ ifndef MAC_OS
 PREFIX                    ?=
 BIN_PATH             			?=$(PREFIX)/usr# /bin is appended later
 BIN_AFTER_INST_PATH				?=$(BIN_PATH)# needed for debian package and desktop file exec
+ifdef GENTOO_OS
 LIB_PATH 	           			?=$(PREFIX)/usr/lib64/oidc-agent
 LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib64/oidc-agent
 INCLUDE_PATH         			?=$(PREFIX)/usr/include
+else ifdef ARCHLINUX_OS
+LIB_PATH 	           			?=$(PREFIX)/usr/lib/oidc-agent
+LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/oidc-agent
+INCLUDE_PATH         			?=$(PREFIX)/usr/include
+else
+LIB_PATH 	           			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
+LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
+INCLUDE_PATH         			?=$(PREFIX)/usr/include/x86_64-linux-gnu
+endif
 MAN_PATH             			?=$(PREFIX)/usr/share/man
 CONFIG_PATH          			?=$(PREFIX)/etc
 BASH_COMPLETION_PATH 			?=$(PREFIX)/usr/share/bash-completion/completions

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ LINKER   = gcc
 ifdef MAC_OS
 LFLAGS   = -lsodium -largp
 else
-LFLAGS   = -l:libsodium.so -lseccomp -fno-common
+LFLAGS   = -lsodium -lseccomp -fno-common
 endif
 ifdef HAS_CJSON
 	LFLAGS += -lcjson

--- a/Makefile
+++ b/Makefile
@@ -93,15 +93,6 @@ ifndef MAC_OS
 PREFIX                    ?=
 BIN_PATH             			?=$(PREFIX)/usr# /bin is appended later
 BIN_AFTER_INST_PATH				?=$(BIN_PATH)# needed for debian package and desktop file exec
-ifdef GENTOO_OS
-LIB_PATH 	           			?=$(PREFIX)/usr/lib64/oidc-agent
-LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib64/oidc-agent
-INCLUDE_PATH         			?=$(PREFIX)/usr/include
-else ifdef ARCHLINUX_OS
-LIB_PATH 	           			?=$(PREFIX)/usr/lib/oidc-agent
-LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/oidc-agent
-INCLUDE_PATH         			?=$(PREFIX)/usr/include
-else
 LIB_PATH 	           			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
 LIBDEV_PATH 	       			?=$(PREFIX)/usr/lib/x86_64-linux-gnu
 INCLUDE_PATH         			?=$(PREFIX)/usr/include/x86_64-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ LINKER   = gcc
 ifdef MAC_OS
 LFLAGS   = -lsodium -largp
 else
-LFLAGS   = -l:libsodium.a -lseccomp -fno-common
+LFLAGS   = -l:libsodium.so -lseccomp -fno-common
 endif
 ifdef HAS_CJSON
 	LFLAGS += -lcjson


### PR DESCRIPTION
Change libsodium dependency from static library .a to dynamic library .so.
Archlinux compiles as default libsodium for shared object library .so instead of .a.
Gentoo also have flag static-libs disabled as default.
With this PR is now possible to compile oidc-agent with the shared object instead of the static library.

Fix: #239 