### PR TITLE
More documentation

### DIFF
--- a/gitbook/oidc-agent/options.md
+++ b/gitbook/oidc-agent/options.md
@@ -1,19 +1,23 @@
-## Detailed Information About All Options
+## Short Information About All Options
 
-* [`--always-allow-idtoken`](#always-allow-idtoken)
-* [`--confirm`](#confirm)
-* [`--console`](#console)
-* [`--debug`](#debug)
-* [`--kill`](#kill)
-* [`--no-autoload`](#no-autoload)
-* [`--no-scheme`](#no-scheme)
-* [`--no-webserver`](#no-webserver)
-* [`--pw-store`](#pw-store)
-* [`--seccomp`](#seccomp)
-* [`--lifetime`](#lifetime)
-* [`--log-stderr`](#log-stderr)
-* [`--status`](#status)
-* [`--with-group`](#with-group)
+| Option | Effect |
+| -- | -- |
+| [`--always-allow-idtoken`](#always-allow-idtoken) |Always allow id-token requests without manual approval by the user
+| [`--confirm`](#confirm) |Requires user confirmation when an application requests an access token for any loaded
+| [`--console`](#console) |Runs `oidc-agent` on the console, without daemonizing
+| [`--debug`](#debug) | Sets the log level to DEBUG
+| [`--kill`](#kill) |Kill the current agent (given by the OIDCD_PID environment variable)
+| [`--no-autoload`](#no-autoload) |Disables the autoload feature: A token request cannot load the needed configuration
+| [`--no-scheme`](#no-scheme) | `oidc-agent` will not use a custom uri scheme redirect [Only applies if authorization code flow is used]
+| [`--no-webserver`](#no-webserver) | `oidc-agent` will not start a webserver [Only applies if authorization code flow is used]
+| [`--pw-store`](#pw-store) |Keeps the encryption passwords for all loaded account configurations encrypted in memory [..]
+| [`--seccomp`](#seccomp) |Enables seccomp system call filtering; allows only predefined system calls
+| [`--lifetime`](#lifetime) |Sets a default value in seconds for the maximum lifetime of account configurations [..]
+| [`--log-stderr`](#log-stderr) |Additionally prints log messages to stderr
+| [`--status`](#status) |Connects to the currently running agent and prints status information
+| [`--with-group`](#with-group) |Applications running under another user can access the agent [..]
+
+## Detailed explanation About All Options
 
 ### `--always-allow-idtoken`
 `oidc-token` can also be used to request an id token from the agent. On
@@ -34,7 +38,7 @@ confirmation, or when starting the agent. If the option is used with the agent,
 every usage of every account configuration has to be approved by the user.
 
 ### `--console`
-Usually oidc-agent runs in the background as a daemon. This option will skip
+Usually `oidc-agent` runs in the background as a daemon. This option will skip
 the daemonizing and run on the console. This might be sued for debugging.
 
 ### `--debug`
@@ -82,7 +86,7 @@ redirect to and pass it to `oidc-gen --codeExchange`.
 ### `--pw-store`
 When this option is provided, the encryption password for all account
 configurations  will be kept in memory by
-oidc-agent (in an encrypted way).
+`oidc-agent` (in an encrypted way).
 
 This option can also be sued with `oidc-add`. When this option is used with
 `oidc-agent` it applies to all loaded account configuration; when used with
@@ -96,7 +100,7 @@ notes](../security/seccomp.md) for more details.
 ### `--lifetime`
 The `--lifetime` option can be used to set a default lifetime for all loaded account
 configurations. This way all account configurations will only be loaded for a
-limited time after which they are automatically removed from the agent. 
+limited time after which they are automatically removed from the agent.
 When loading an account configuration with `oidc-add` this lifetime can be
 overwritten. So that a specific account configuration can be loaded with another
 lifetime (lower, higher, and also infinite).

--- a/gitbook/provider/helmholtz.md
+++ b/gitbook/provider/helmholtz.md
@@ -1,14 +1,20 @@
-## Helmholtz AAI 
+## Helmholtz AAI
 Helmholtz AAI does not support dynamic client registration, but there is a
-preregistered public client so that account configuration generation is as easy
+preregistered public client which can be used so that account configuration is as easy
 as with dynamic client registration.
 
-### Quickstart
-Example:
+### Use Preregistered Public Client
+
+Enter the following command and follow the instructions to take advantage of the preregistered public client:
+```
+$ oidc-gen --pub --issuer https://login.helmholtz.de/oauth2/ <shortname>
+```
+
+Example output:
 ```
 $ oidc-gen --pub --issuer https://login.helmholtz.de/oauth2/ <shortname>
 [...]
-Space delimited list of scopes [openid profile offline_access]: 
+Space delimited list of scopes [openid profile offline_access]:
 Generating account configuration ...
 accepted
 To continue and approve the registered client visit the following URL in a Browser of your choice:
@@ -17,13 +23,12 @@ https://[...]
 success
 The generated account config was successfully added to oidc-agent. You don't have to run oidc-add.
 
-Enter encryption password for account configuration '<shortname>': 
-Confirm encryption Password: 
+Enter encryption password for account configuration '<shortname>':
+Confirm encryption Password:
 ```
 
-### Advanced options
+### Manual Client registration
 
-#### Manual Client registration
 - Make sure you **don’t** have an active login in unity and visit the /home endpoint (i.e. https://login.helmholtz.de/home )
 - **Don't login**
 - Click "Register a new account" on the top right
@@ -49,7 +54,4 @@ Values](client-configuration-values.md#redirect-uri) for
 more information).
 
 After the client is registered, call oidc-gen with the `-m` flag and enter the
-required information. 
-
-
-
+required information.


### PR DESCRIPTION
This adds documentation at two levels:

1. Application usage. A short summary of the options helps sometimes but the explanations should also be brief. I added the ones from the help menu to the documentation.
2. Helmholtz AAI and the preconfigured client was unclear for me as a first time user. I just read, that there is one and the next section was simply a shell dump. I ignored it and went straight below. Only after a comment by Sander I got the full picture. Hope the structure now helps newcomers better.
3. Removed the single subsection of the `Advanced Setup` since it was the only one. Should be clearer now. 