### PR TITLE
Add error handling to oidc-agent status command

### DIFF
--- a/src/oidc-agent/oidcp/oidcp.c
+++ b/src/oidc-agent/oidcp/oidcp.c
@@ -83,9 +83,14 @@ int main(int argc, char** argv) {
   }
   if (arguments.status) {
     char* res  = ipc_cryptCommunicate(0, REQUEST_STATUS);
+    if (res == NULL) {
+      oidc_perror();
+      exit(EXIT_FAILURE);
+    }
     char* info = parseForInfo(res);
     if (info == NULL) {
       oidc_perror();
+      exit(EXIT_FAILURE);
     }
     printNormal(info);
     secFree(info);


### PR DESCRIPTION
This commit fixes a "bug" when oidc-agent --status is called and the oidc agent is not reachable (e.g. due to a not set environment variable). The old output looks like this

```text
Could not get the socket path from env var 'OIDC_SOCK'. Have you set the env var?
Could not decode json: (null)
This seems to be a bug. Please hand in a bug report.
Error: Argument is NULL in function getJSONValuesFromString
```

After this commit, the output looks like

```text
Could not get the socket path from env var 'OIDC_SOCK'. Have you set the env var?
Error: Env var not set
```

and the exit code becomes 1 (EXIT_FAILURE) in those cases.