### PR TITLE
Print status message on stdout instead of stderr

### DIFF
--- a/src/oidc-gen/gen_handler.c
+++ b/src/oidc-gen/gen_handler.c
@@ -129,7 +129,7 @@ void handleGen(struct oidc_account* account, const struct arguments* arguments,
   char* hint = oidc_sprintf("account configuration '%s'", name);
   gen_saveAccountConfig(json, account_getName(account), hint,
                         suggested_password, arguments);
-  printNormal("Everything setup correctly!\n");
+  printStdout("Everything setup correctly!\n");
   secFree(hint);
   secFree(name);
   secFreeAccount(account);


### PR DESCRIPTION
I believe a success message should be written on stdout instead of stderr for consistency reasons (as this status message is not an error and using this command there is already plenty other status text on stdout).