### PR TITLE
Work around for libcjson bug in ubuntu-focal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -754,6 +754,8 @@ focal-debsource: distclean preparedeb
 	@cat debian/rules.bck \
 		| sed s/^"export USE_CJSON_SO = 1"/"export USE_CJSON_SO = 0"/ \
 		> debian/rules
+	@chmod 755 debian/rules
+	dpkg-source -b .
 	
 .PHONY: bionic-debsource
 bionic-debsource: distclean preparedeb

--- a/Makefile
+++ b/Makefile
@@ -753,7 +753,7 @@ focal-debsource: distclean preparedeb
 	@mv debian/rules debian/rules.bck
 	@cat debian/rules.bck \
 		| sed s/^"export USE_CJSON_SO = 1"/"export USE_CJSON_SO = 0"/ \
-		> debian.rules
+		> debian/rules
 	
 .PHONY: bionic-debsource
 bionic-debsource: distclean preparedeb

--- a/Makefile
+++ b/Makefile
@@ -752,7 +752,7 @@ buster-debsource: distclean preparedeb
 focal-debsource: distclean preparedeb
 	@mv debian/rules debian/rules.bck
 	@cat debian/rules.bck \
-		| sed s/^"export USE_CJSON_SO = 1"/"export USE_CJSON_SO = 0" \
+		| sed s/^"export USE_CJSON_SO = 1"/"export USE_CJSON_SO = 0"/ \
 		> debian.rules
 	
 .PHONY: bionic-debsource

--- a/Makefile
+++ b/Makefile
@@ -748,6 +748,13 @@ buster-debsource: distclean preparedeb
 		> debian/control
 	dpkg-source -b .
 
+.PHONY: focal-debsource
+focal-debsource: distclean preparedeb
+	@mv debian/rules debian/rules.bck
+	@cat debian/rules.bck \
+		| sed s/^"export USE_CJSON_SO = 1"/"export USE_CJSON_SO = 0" \
+		> debian.rules
+	
 .PHONY: bionic-debsource
 bionic-debsource: distclean preparedeb
 	# re-add the desktop triggers by hand, because I'm not sure about the

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-oidc-agent (4.1.0-4) UNRELEASED; urgency=medium
+oidc-agent (4.1.0-5) UNRELEASED; urgency=medium
 
   [ Marcus hardt ]
   * Also accept libcurl4 as a dependency
@@ -28,6 +28,7 @@ oidc-agent (4.1.0-4) UNRELEASED; urgency=medium
     replace older versions of oidc-agent package
   * oidc-agent-desktop is now only suggested (not recommended)
   * liboidc-agent now suggestst oidc-agent-cli (before: recommend oidc-agent)
+  * Add special handling for buggy libcjson in ubuntu-focal)
   * Closes: #980462
 
  -- Marcus Hardt <marcus@hardt-it.de>  Fri, 09 Oct 2020 21:33:36 +0200


### PR DESCRIPTION
Use an updated version of libcjson from git.