### PR TITLE
exclude log files from account list

### DIFF
--- a/src/utils/file_io/fileUtils.c
+++ b/src/utils/file_io/fileUtils.c
@@ -114,6 +114,9 @@ int isAccountConfigFile(const char* filename,
   if (strEnds(filename, ".config")) {
     return 0;
   }
+  if (strEnds(filename, ".log")) {
+    return 0;
+  }
   return 1;
 }
 


### PR DESCRIPTION
On MacOS oidc-agent writes to a log file in the config directory, which
was unintentionally being returned as an account config when
running oidc-gen --accounts or oidc-add --list. This change excludes
any files ending in .log from the account list command output.

Fixes #335