### PR TITLE
allow specifying socket path not under /tmp

### DIFF
--- a/src/ipc/serveripc.c
+++ b/src/ipc/serveripc.c
@@ -24,10 +24,22 @@
 #include <time.h>
 #include <unistd.h>
 
-#define SOCKET_DIR "/tmp/oidc-XXXXXX"
+#define SOCKET_TMP_DIR "/tmp"
+#define SOCKET_DIR_PAT "oidc-XXXXXX"
 
 static char* oidc_ipc_dir       = NULL;
 static char* server_socket_path = NULL;
+
+
+static char* get_socket_dir_pat()
+{
+  const char* tmpdir = getenv("TMPDIR");
+  if (!tmpdir || !tmpdir[0]) {
+    tmpdir = SOCKET_TMP_DIR;
+  }
+  const char* fmt = "%s/%s";
+  return oidc_sprintf(fmt, tmpdir, SOCKET_DIR_PAT);
+}
 
 /**
  * @brief generates the socket path and prints commands for setting env vars
@@ -39,7 +51,7 @@ static char* server_socket_path = NULL;
  */
 char* init_socket_path(const char* group_name) {
   if (NULL == oidc_ipc_dir) {
-    oidc_ipc_dir = oidc_strcopy(SOCKET_DIR);
+    oidc_ipc_dir = get_socket_dir_pat();
     if (mkdtemp(oidc_ipc_dir) == NULL) {
       logger(ALERT, "%m");
       oidc_errno = OIDC_EMKTMP;


### PR DESCRIPTION
Greetings!

We would like to specify an explicit socket path for `oidc-agent` to use.  The other `oidc-*` programs use whatever is specified in the `OIDC_SOCK` env var, but `oidc-agent` generates it with a hard-coded `/tmp/oidc-XXXXXX` template for `mkdtemp(3)`.

How would you feel about providing a way for `oidc-agent` to create its socket file somewhere other than under `/tmp` ?

Ideas include:
- add a command-line option to specify the target oidc socket file path
- use `OIDC_SOCK` if specified
- use a different `OIDC_*` env var for this purpose
  (if for instance you are worried about collision with an existing `OIDC_SOCK` from a previous `oidc-agent` run)
- respect the `TMPDIR` env var, if set, for providing a base location other than `/tmp`

The last option seemed like the lowest-hanging fruit, so that's what i've implemented in this PR; but i'd be happy with any solution to the problem that lets us specify another location for the socket file, or at least the base directory for it.

Thanks for your consideration!