### PR TITLE
Fix source name in SPEC file for rpmbuild

### DIFF
--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -12,7 +12,7 @@ URL: https://github.com/indigo-dc/oidc-agent
 # use `make rpmsource` to generate the required tarball
 #Source0: https://github.com/indigo-dc/oidc-agent/archive/refs/heads/master.zip
 #Source0: https://github.com/indigo-dc/oidc-agent/archive/refs/heads/docker-builds.zip
-Source0: https://github.com/indigo-dc/oidc-agent/archive/refs/tags/v%{version}.tar.gz
+Source0: https://github.com/indigo-dc/oidc-agent/archive/refs/tags/%{name}-%{version}.tar.gz
 #DO_NOT_REPLACE_THIS_LINE
 
 BuildRequires: gcc >= 4.8


### PR DESCRIPTION
`make rpm` produces the following output:
```
test -e rpm/rpmbuild/SOURCES || mkdir -p rpm/rpmbuild/SOURCES
mv ../oidc-agent-4.2.2.tar.gz rpm/rpmbuild/SOURCES
rpmbuild --define "_topdir /root/oidc-agent/rpm/rpmbuild" -bb  rpm/oidc-agent.spec
error: File /root/oidc-agent/rpm/rpmbuild/SOURCES/v4.2.2.tar.gz: No such file or directory
make: *** [rpm] Error 1
```
A change in the `oidc-agent.spec` file is needed to fetch the correct `tar.gz` from Github