### PR TITLE
Makefile: honour user-set toolchain variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,9 @@ ifdef MAC_OS
 endif
 
 # Compiler options
-CC       = gcc
+CC       := $(CC)
 # compiling flags here
-CFLAGS   = -g -std=c99 -I$(SRCDIR) -I$(LIBDIR)  -Wall -Wextra -fno-common
+CFLAGS   := $(CFLAGS) -g -std=c99 -I$(SRCDIR) -I$(LIBDIR)  -Wall -Wextra -fno-common
 ifndef MAC_OS
 ifndef NODPKG
 	CFLAGS   +=$(shell dpkg-buildflags --get CPPFLAGS)
@@ -106,11 +106,11 @@ endif
 TEST_CFLAGS = $(CFLAGS) -I.
 
 # Linker options
-LINKER   = gcc
+LINKER   := $(CC)
 ifdef MAC_OS
 LFLAGS   = $(LSODIUM) $(LARGP)
 else
-LFLAGS   = $(LSODIUM) $(LSECCOMP) -fno-common -Wl,-z,now
+LFLAGS   := $(LDFLAGS) $(LSODIUM) $(LSECCOMP) -fno-common -Wl,-z,now
 ifndef NODPKG
 LFLAGS +=$(shell dpkg-buildflags --get LDFLAGS)
 endif
@@ -130,12 +130,12 @@ ADD_LFLAGS = $(LFLAGS)
 ifdef MAC_OS
 CLIENT_LFLAGS = -L$(APILIB) $(LARGP) $(LAGENT) $(LSODIUM)
 else
-CLIENT_LFLAGS = -L$(APILIB) $(LAGENT) $(LSODIUM) $(LSECCOMP)
+CLIENT_LFLAGS := $(LDFLAGS) -L$(APILIB) $(LAGENT) $(LSODIUM) $(LSECCOMP)
 ifndef NODPKG
 	CLIENT_LFLAGS += $(shell dpkg-buildflags --get LDFLAGS)
 endif
 endif
-LIB_LFLAGS = -lc $(LSODIUM)
+LIB_LFLAGS := $(LDFLAGS) -lc $(LSODIUM)
 ifndef MAC_OS
 ifndef NODPKG
 	LIB_LFLAGS += $(shell dpkg-buildflags --get LDFLAGS)


### PR DESCRIPTION
This allows adding custom compiler and linker flags (e.g. to enable stack-smashing protection or link-time optimisation), as well as specifying a custom compiler/linker (e.g. to use clang - which by the way appears to work fine here - instead of gcc).

At the moment custom compiler/linker flags are not applied on macOS because I am not sure if they use the same variable names in this context, will be trivial to extend once someone has clarified this though.

Signed-off-by: Marek Szuba <marek.szuba@cern.ch>