### PR TITLE
Dev 4.3.0 packaging

### DIFF
--- a/docker/centos:7.dependencies
+++ b/docker/centos:7.dependencies
@@ -2,8 +2,10 @@ desktop-file-utils
 help2man
 libcurl-devel
 libmicrohttpd-devel
-libseccomp-devel
 libsecret-devel
 libsodium-devel
 libsodium-static
 qrencode-devel
+golang
+gtk3-devel
+webkit2gtk3-devel

--- a/docker/debian:bullseye.dependencies
+++ b/docker/debian:bullseye.dependencies
@@ -4,7 +4,9 @@ libcjson-dev
 libcurl4-openssl-dev
 libmicrohttpd-dev
 libqrencode-dev
-libseccomp-dev
 libsecret-1-dev
 libsodium-dev
 pkg-config
+golang
+libgtk-3-dev
+libwebkit2gtk-4.0-dev

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -101,7 +101,7 @@ common_prepare_dirs
             apt install -y \
                 $OUTPUT/$DIST/liboidc-agent-dev_4*deb || exit 3
         ;;
-        fedora_*|centos_*)
+    fedora_*|centos_*|rockylinux*)
             echo -e "\n\ninstalling oidc-agent-cli and liboidc-agent4"
             yum install -y \
                 $OUTPUT/$DIST/oidc-agent-cli-4*rpm \
@@ -140,11 +140,7 @@ common_prepare_dirs
             buster_build_package
             debian_copy_output
         ;;
-        ubuntu_bionic)
-            bionic_build_package
-            debian_copy_output
-        ;;
-        ubuntu_focal|ubuntu_hirsute|ubuntu_impish)
+        ubuntu_*)
             focal_build_package
             debian_copy_output
         ;;
@@ -153,7 +149,7 @@ common_prepare_dirs
             rpm_build_package
             rpm_copy_output
         ;;
-        centos_8|centos_7|fedora*)
+        centos_8|centos_7|fedora*|rockylinux*)
             rpm_build_package
             rpm_copy_output
         ;;

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -9,10 +9,16 @@ DOCKER_RUN_PARAMS=--tty -it --rm
 
 SHELL=bash
 
+# export DOCKER_OPTIONS="--no-cache" to use this
+#DOCKER_OPTIONS 				= "--no-cache"
+
 DOCKER_GEN_FROM_IMAGE			= "FROM `echo $@ | sed s/docker_//| cut -d: -f 1`:`echo $@ | sed s/docker_//| cut -d: -f 2`"
 
+DOCKER_APT_BULLSEYE_BACKPORTS	= "RUN echo 'deb http://deb.debian.org/debian bullseye-backports main contrib non-free' > /etc/apt/sources.list.d/bullseye-backports.list"
+DOCKER_APT_BACKPORTS_KEYS		= "RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9"
 DOCKER_APT_INIT                 = "ENV DEBIAN_FRONTEND noninteractive\nRUN apt update && apt -y upgrade"
 DOCKER_APT_BUILD_ESSENTIALS     = "RUN apt install -y build-essential dh-make quilt devscripts"
+DOCKER_APT_BULLSEYE_GOLANG	 	= "RUN apt-get update && apt-get install -y -t bullseye-backports golang"
 
 DOCKER_YUM_DISABLE_FASTESTMIRROR= "RUN sed s/enabled=1/enabled=0/ -i /etc/yum/pluginconf.d/fastestmirror.conf"
 DOCKER_YUM_BUILD_ESSENTIALS     = "RUN yum -y install make rpm-build"
@@ -59,90 +65,82 @@ DOCKER_CONTAINER				= "`echo $@ | sed s/dockerised_test_//\
 .PHONY: dockerised_latest_packages
 dockerised_latest_packages: dockerised_deb_debian_bullseye\
 	dockerised_deb_debian_bookworm\
-	dockerised_deb_ubuntu_focal\
-	dockerised_deb_ubuntu_hirsute\
+	dockerised_deb_ubuntu_jammy\
+	dockerised_rpm_rockylinux_8\
 	dockerised_rpm_centos_8\
 	dockerised_rpm_opensuse_tumbleweed\
-	dockerised_rpm_fedora35
+	dockerised_rpm_fedora_36
 
 .PHONY: dockerised_all_deb_packages
-dockerised_all_deb_packages: dockerised_deb_debian_buster\
-	dockerised_deb_debian_bullseye\
+dockerised_all_deb_packages: dockerised_deb_debian_bullseye\
 	dockerised_deb_debian_bookworm\
-	dockerised_deb_ubuntu_bionic\
 	dockerised_deb_ubuntu_focal\
+	dockerised_deb_ubuntu_jammy\
+	dockerised_deb_ubuntu_impish\
 	dockerised_deb_ubuntu_hirsute
 
 .PHONY: dockerised_all_rpm_packages
-dockerised_all_rpm_packages: dockerised_rpm_centos_7\
-	dockerised_rpm_centos_8\
-	dockerised_rpm_opensuse_15.2\
+dockerised_all_rpm_packages: dockerised_rpm_rockylinux_8.5\
 	dockerised_rpm_opensuse_15.3\
+	dockerised_rpm_opensuse_15.4\
 	dockerised_rpm_opensuse_tumbleweed\
-	dockerised_rpm_fedora_34
+	dockerised_rpm_fedora_36
 
 .PHONY: dockerised_all_packages
-dockerised_all_packages: dockerised_deb_debian_buster\
-	dockerised_deb_debian_bullseye\
-	dockerised_deb_debian_bookworm\
-	dockerised_deb_ubuntu_bionic\
-	dockerised_deb_ubuntu_focal\
-	dockerised_deb_ubuntu_hirsute\
-	dockerised_rpm_centos_7\
-	dockerised_rpm_centos_8\
-	dockerised_rpm_opensuse_15.2\
-	dockerised_rpm_opensuse_15.3\
-	dockerised_rpm_opensuse_tumbleweed\
-	dockerised_rpm_fedora_34
+dockerised_all_packages: dockerised_all_rpm_packages\
+	dockerised_all_deb_packages
 
 .PHONY: dockerised_test_all
 dockerised_test_all: dockerised_test_debs\
 	dockerised_test_rpms
 
 .PHONY: dockerised_test_debs
-dockerised_test_debs: dockerised_test_debian_buster\
-	dockerised_test_debian_bullseye\
+dockerised_test_debs: dockerised_test_debian_bullseye\
 	dockerised_test_debian_bookworm\
-	dockerised_test_ubuntu_bionic\
 	dockerised_test_ubuntu_focal\
+	dockerised_test_ubuntu_jammy\
+	dockerised_test_ubuntu_impish\
 	dockerised_test_ubuntu_hirsute
 
 .PHONY: dockerised_test_rpms
 dockerised_test_rpms: dockerised_test_rockylinux_8.5\
 	dockerised_test_fedora_36\
 	dockerised_test_opensuse_15.3\
+	dockerised_test_opensuse_15.4\
 	dockerised_test_opensuse_tumbleweed
 
 .PHONY: docker_images
-docker_images: docker_debian\:buster\
-	docker_debian\:bullseye\
+docker_images: docker_debian\:bullseye\
 	docker_debian\:bookworm\
-	docker_ubuntu\:bionic\
 	docker_ubuntu\:focal\
+	docker_ubuntu\:jammy\
+	docker_ubuntu\:impish\
 	docker_ubuntu\:hirsute\
 	docker_centos\:7\
 	docker_centos\:8\
 	docker_registry.opensuse.org/opensuse/leap\:15.2\
 	docker_registry.opensuse.org/opensuse/leap\:15.3\
+	docker_registry.opensuse.org/opensuse/leap\:15.4\
 	docker_registry.opensuse.org/opensuse/tumbleweed\:latest\
 	docker_fedora\:34
 
 .PHONY: docker_clean
 docker_clean:
-	echo docker image rm build-$(PACKAGE_DIR)-debian:buster 		|| true
 	@docker image rm build-$(PACKAGE_DIR)-debian:bullseye			|| true
 	@docker image rm build-$(PACKAGE_DIR)-debian:bookworm			|| true
-	@docker image rm build-$(PACKAGE_DIR)-ubuntu:bionic				|| true
 	@docker image rm build-$(PACKAGE_DIR)-ubuntu:focal				|| true
+	@docker image rm build-$(PACKAGE_DIR)-ubuntu:jammy				|| true
 	@docker image rm build-$(PACKAGE_DIR)-ubuntu:hirsute				|| true
 	@docker image rm build-$(PACKAGE_DIR)-ubuntu:impish				|| true
 	@docker image rm build-$(PACKAGE_DIR)-centos:7					|| true
 	@docker image rm build-$(PACKAGE_DIR)-centos:8					|| true
 	@docker image rm build-$(PACKAGE_DIR)-opensuse_leap:15.2			|| true
 	@docker image rm build-$(PACKAGE_DIR)-opensuse_leap:15.3			|| true
+	@docker image rm build-$(PACKAGE_DIR)-opensuse_leap:15.4			|| true
 	@docker image rm build-$(PACKAGE_DIR)-opensuse_tumbleweed:latest	|| true
 	@docker image rm build-$(PACKAGE_DIR)-fedora:34					|| true
 	@docker image rm build-$(PACKAGE_DIR)-fedora:35					|| true
+	@docker image rm build-$(PACKAGE_DIR)-fedora:36					|| true
 
 ########################################## DEBIAN ##########################################
 .PHONY: dockerised_deb_buster
@@ -158,7 +156,9 @@ docker_debian\:buster:
 	@test -d docker/log || mkdir -p docker/log
 	@echo -e \
 	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	$(DOCKER_APT_BULLSEYE_BACKPORTS)"\n" \
 	$(DOCKER_APT_INIT)"\n" \
+	$(DOCKER_APT_BULLSEYE_GOLANG)"\n" \
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
@@ -180,11 +180,13 @@ docker_debian\:bullseye:
 	@test -d docker/log || mkdir -p docker/log
 	@echo -e \
 	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	$(DOCKER_APT_BULLSEYE_BACKPORTS)"\n" \
 	$(DOCKER_APT_INIT)"\n" \
+	$(DOCKER_APT_BULLSEYE_GOLANG)"\n" \
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_debian_bullseye:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -206,7 +208,7 @@ docker_debian\:bookworm:
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_debian_bookworm:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -214,6 +216,7 @@ dockerised_test_debian_bookworm:
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
 ########################################## UBUNTU ##########################################
+# 18.04
 .PHONY: dockerised_deb_ubuntu_bionic
 dockerised_deb_ubuntu_bionic: docker_ubuntu\:bionic
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -228,14 +231,18 @@ docker_ubuntu\:bionic:
 	$(DOCKER_APT_INIT)"\n" \
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
+	$(DOCKER_APT_BULLSEYE_BACKPORTS)"\n" \
+	$(DOCKER_APT_BACKPORTS_KEYS)"\n" \
+	$(DOCKER_APT_BULLSEYE_GOLANG)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_ubuntu_bionic:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
+# 20.04
 .PHONY: dockerised_deb_ubuntu_focal
 dockerised_deb_ubuntu_focal: docker_ubuntu\:focal
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -250,14 +257,18 @@ docker_ubuntu\:focal:
 	$(DOCKER_APT_INIT)"\n" \
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
+	$(DOCKER_APT_BULLSEYE_BACKPORTS)"\n" \
+	$(DOCKER_APT_BACKPORTS_KEYS)"\n" \
+	$(DOCKER_APT_BULLSEYE_GOLANG)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_ubuntu_focal:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
+# 21.04
 .PHONY: dockerised_deb_ubuntu_hirsute
 dockerised_deb_ubuntu_hirsute: docker_ubuntu\:hirsute
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -273,13 +284,14 @@ docker_ubuntu\:hirsute:
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_ubuntu_hirsute:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
+# 21.10
 .PHONY: dockerised_deb_ubuntu_impish
 dockerised_deb_ubuntu_impish: docker_ubuntu\:impish
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -295,7 +307,7 @@ docker_ubuntu\:impish:
 	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_APT_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_ubuntu_impish:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -345,7 +357,7 @@ docker_centos\:7:
 	$(DOCKER_YUM_EPEL_RELEASE)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_YUM_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_centos_7:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -369,8 +381,32 @@ docker_centos\:8:
 	$(DOCKER_YUM_ENABLE_POWERTOOLS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_YUM_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_centos_8:
+	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
+
+.PHONY: dockerised_rpm_rockylinux_8.5
+dockerised_rpm_rockylinux_8.5: docker_rockylinux\:8.5
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-rockylinux:8.5 \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
+.PHONY: docker_rockylinux\:8.5
+docker_rockylinux\:8.5: 
+	@echo Logging to ${DOCKER_LOG}
+	@test -d docker/log || mkdir -p docker/log
+	@echo -e \
+	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	$(DOCKER_YUM_BUILD_ESSENTIALS)"\n" \
+	$(DOCKER_YUM_GROUPS_DEVELTOOLS)"\n" \
+	$(DOCKER_YUM_REMI_RELEASE)"\n" \
+	$(DOCKER_YUM_ENABLE_POWERTOOLS)"\n" \
+	$(DOCKER_COPY_DEPENDENCIES)"\n" \
+	$(DOCKER_YUM_INST_DEPENDENCIES) \
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+dockerised_test_rockylinux_8.5:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
@@ -392,7 +428,7 @@ docker_registry.opensuse.org/opensuse/leap\:15.2:
 	$(DOCKER_ZYP_GROUP_DEVEL)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_ZYP_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
 dockerised_test_opensuse_15.2:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -414,8 +450,30 @@ docker_registry.opensuse.org/opensuse/leap\:15.3:
 	$(DOCKER_ZYP_GROUP_DEVEL)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_ZYP_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
 dockerised_test_opensuse_15.3:
+	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
+
+.PHONY: dockerised_rpm_opensuse_15.4
+dockerised_rpm_opensuse_15.4: docker_registry.opensuse.org/opensuse/leap\:15.4
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
+.PHONY: docker_registry.opensuse.org/opensuse/leap\:15.4
+docker_registry.opensuse.org/opensuse/leap\:15.4:
+	@echo Logging to ${DOCKER_LOG}
+	@test -d docker/log || mkdir -p docker/log
+	@echo -e \
+	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	$(DOCKER_ZYP_BUILD_ESSENTIALS)"\n" \
+	$(DOCKER_ZYP_GROUP_DEVEL)"\n" \
+	$(DOCKER_COPY_DEPENDENCIES)"\n" \
+	$(DOCKER_ZYP_INST_DEPENDENCIES) \
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
+dockerised_test_opensuse_15.4:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
@@ -436,7 +494,7 @@ docker_registry.opensuse.org/opensuse/tumbleweed\:latest:
 	$(DOCKER_ZYP_GROUP_DEVEL)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_ZYP_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f -  . >> ${DOCKER_LOG}
 dockerised_test_opensuse_tumbleweed:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -459,7 +517,7 @@ docker_fedora\:34:
 	$(DOCKER_YUM_GROUPS_DEVELTOOLS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_YUM_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 dockerised_test_fedora_34:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
@@ -478,13 +536,33 @@ docker_fedora\:35:
 	@test -d docker/log || mkdir -p docker/log
 	echo -e \
 	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	"COPY docker/RPM-GPG-KEY-fedora-37-primary /etc/pki/rpm-gpg/\n" \
+	"RUN sed 's_basearch\$$_basearch file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-37-primary_' -i /etc/yum.repos.d/fedora-rawhide.repo\n" \
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+dockerised_test_fedora_35:
+	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
+
+.PHONY: dockerised_rpm_fedora_36
+dockerised_rpm_fedora_36: docker_fedora\:36
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-fedora:36\
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
+.PHONY: docker_fedora\:36
+docker_fedora\:36: 
+	@echo Logging to ${DOCKER_LOG}
+	@test -d docker/log || mkdir -p docker/log
+	@echo -e \
+	$(DOCKER_GEN_FROM_IMAGE)"\n" \
 	$(DOCKER_YUM_BUILD_ESSENTIALS)"\n" \
 	"RUN echo \"nameserver 9.9.9.9\" > /etc/resolv.conf \n" \
 	$(DOCKER_YUM_GROUPS_DEVELTOOLS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_YUM_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
-dockerised_test_fedora_35:
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+dockerised_test_fedora_36:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
@@ -499,13 +577,13 @@ dockerised_rpm_fedora_rawhide: docker_fedora\:rawhide
 docker_fedora\:rawhide: 
 	@echo Logging to ${DOCKER_LOG}
 	@test -d docker/log || mkdir -p docker/log
-	echo -e \
+	@echo -e \
 	$(DOCKER_GEN_FROM_IMAGE)"\n" \
 	$(DOCKER_YUM_BUILD_ESSENTIALS)"\n" \
 	$(DOCKER_YUM_GROUPS_DEVELTOOLS)"\n" \
 	$(DOCKER_COPY_DEPENDENCIES)"\n" \
 	$(DOCKER_YUM_INST_DEPENDENCIES) \
-	| docker build --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
 
 delme:
 	"RUN sed s_https://_http://_g -i /etc/yum.repos.d/*repo \n" \

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -96,18 +96,8 @@ dockerised_all_packages: dockerised_deb_debian_buster\
 	dockerised_rpm_fedora_34
 
 .PHONY: dockerised_test_all
-dockerised_test_all: dockerised_test_debian_buster\
-	dockerised_test_debian_bullseye\
-	dockerised_test_debian_bookworm\
-	dockerised_test_ubuntu_bionic\
-	dockerised_test_ubuntu_focal\
-	dockerised_test_ubuntu_hirsute\
-	dockerised_test_centos_7\
-	dockerised_test_centos_8\
-	dockerised_test_fedora_34\
-	dockerised_test_opensuse_15.2\
-	dockerised_test_opensuse_15.3\
-	dockerised_test_opensuse_tumbleweed
+dockerised_test_all: dockerised_test_debs\
+	dockerised_test_rpms
 
 .PHONY: dockerised_test_debs
 dockerised_test_debs: dockerised_test_debian_buster\
@@ -118,10 +108,8 @@ dockerised_test_debs: dockerised_test_debian_buster\
 	dockerised_test_ubuntu_hirsute
 
 .PHONY: dockerised_test_rpms
-dockerised_test_rpms: dockerised_test_centos_7\
-	dockerised_test_centos_8\
-	dockerised_test_fedora_34\
-	dockerised_test_opensuse_15.2\
+dockerised_test_rpms: dockerised_test_rockylinux_8.5\
+	dockerised_test_fedora_36\
 	dockerised_test_opensuse_15.3\
 	dockerised_test_opensuse_tumbleweed
 
@@ -229,7 +217,7 @@ dockerised_test_debian_bookworm:
 .PHONY: dockerised_deb_ubuntu_bionic
 dockerised_deb_ubuntu_bionic: docker_ubuntu\:bionic
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
-		build-$(PACKAGE_DIR)-ubuntu:bionic \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
 .PHONY: docker_ubuntu\:bionic
 docker_ubuntu\:bionic:
@@ -251,7 +239,7 @@ dockerised_test_ubuntu_bionic:
 .PHONY: dockerised_deb_ubuntu_focal
 dockerised_deb_ubuntu_focal: docker_ubuntu\:focal
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
-		build-$(PACKAGE_DIR)-ubuntu:focal \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
 .PHONY: docker_ubuntu\:focal
 docker_ubuntu\:focal:
@@ -267,13 +255,13 @@ docker_ubuntu\:focal:
 dockerised_test_ubuntu_focal:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
-		build-$(PACKAGE_DIR)-debian:buster \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
 .PHONY: dockerised_deb_ubuntu_hirsute
 dockerised_deb_ubuntu_hirsute: docker_ubuntu\:hirsute
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
-		build-$(PACKAGE_DIR)-ubuntu:hirsute \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
 .PHONY: docker_ubuntu\:hirsute
 docker_ubuntu\:hirsute:
@@ -295,7 +283,7 @@ dockerised_test_ubuntu_hirsute:
 .PHONY: dockerised_deb_ubuntu_impish
 dockerised_deb_ubuntu_impish: docker_ubuntu\:impish
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
-		build-$(PACKAGE_DIR)-ubuntu:impish \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
 .PHONY: docker_ubuntu\:impish
 docker_ubuntu\:impish:
@@ -312,6 +300,29 @@ dockerised_test_ubuntu_impish:
 	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
 	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
 		build-$(PACKAGE_DIR)-${DOCKER_CONTAINER} \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
+
+# 22.04
+.PHONY: dockerised_deb_ubuntu_jammy
+dockerised_deb_ubuntu_jammy: docker_ubuntu\:jammy
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-ubuntu:jammy \
+		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} >> ${DOCKER_BUILD_LOG}
+.PHONY: docker_ubuntu\:jammy
+docker_ubuntu\:jammy:
+	@echo Logging to ${DOCKER_LOG}
+	@test -d docker/log || mkdir -p docker/log
+	@echo -e \
+	$(DOCKER_GEN_FROM_IMAGE)"\n" \
+	$(DOCKER_APT_INIT)"\n" \
+	$(DOCKER_APT_BUILD_ESSENTIALS)"\n" \
+	$(DOCKER_COPY_DEPENDENCIES)"\n" \
+	$(DOCKER_APT_INST_DEPENDENCIES) \
+	| docker build $(DOCKER_OPTIONS) --tag $(DOCKER_TAG) -f - . >> ${DOCKER_LOG}
+dockerised_test_ubuntu_jammy:
+	@echo "Logging $@ to ${DOCKER_BUILD_LOG}"
+	@docker run ${DOCKER_RUN_PARAMS} -v ${DOCKER_BASE}:/home/build \
+		build-$(PACKAGE_DIR)-$(DOCKER_CONTAINER) \
 		/home/build/${PACKAGE_DIR}/docker/docker-build.sh ${PACKAGE_DIR} ${DOCKER_DIST} test >> ${DOCKER_BUILD_LOG}
 
 

--- a/docker/fedora:34.dependencies
+++ b/docker/fedora:34.dependencies
@@ -2,8 +2,11 @@ desktop-file-utils
 help2man
 libcurl-devel
 libmicrohttpd-devel
-libseccomp-devel
 libsecret-devel
 libsodium-devel
 libsodium-static
 qrencode-devel
+golang
+gtk3-devel
+webkit2gtk3-devel
+gcc-c++

--- a/docker/fedora:36.dependencies
+++ b/docker/fedora:36.dependencies
@@ -1,0 +1,1 @@
+fedora:34.dependencies

--- a/docker/opensuse_leap:15.2.dependencies
+++ b/docker/opensuse_leap:15.2.dependencies
@@ -2,9 +2,12 @@ desktop-file-utils
 help2man
 libcurl-devel
 libmicrohttpd-devel
-libseccomp-devel
 libsecret-devel
 libsodium-devel
 libsodium23
 qrencode-devel
 unzip
+golang
+gtk3-devel
+webkit2gtk3-devel
+gcc-c++

--- a/docker/opensuse_leap:15.4.dependencies
+++ b/docker/opensuse_leap:15.4.dependencies
@@ -1,0 +1,1 @@
+opensuse_tumbleweed:latest.dependencies

--- a/docker/opensuse_tumbleweed:latest.dependencies
+++ b/docker/opensuse_tumbleweed:latest.dependencies
@@ -1,1 +1,13 @@
-opensuse_leap:15.2.dependencies
+desktop-file-utils
+help2man
+libcurl-devel
+libmicrohttpd-devel
+libsecret-devel
+libsodium-devel
+libsodium23
+qrencode-devel
+unzip
+golang
+gtk3-devel
+webkit2gtk3-soup2-devel
+gcc-c++

--- a/docker/rockylinux:8.5.dependencies
+++ b/docker/rockylinux:8.5.dependencies
@@ -1,0 +1,1 @@
+fedora:34.dependencies

--- a/docker/ubuntu:bionic.dependencies
+++ b/docker/ubuntu:bionic.dependencies
@@ -3,7 +3,6 @@ help2man
 libcurl4-openssl-dev
 libmicrohttpd-dev
 libqrencode-dev
-libseccomp-dev
 libsecret-1-dev
 libsodium-dev
 pkg-config

--- a/docker/ubuntu:focal.dependencies
+++ b/docker/ubuntu:focal.dependencies
@@ -1,9 +1,12 @@
 check
 help2man
 libcurl4-openssl-dev
+libcjson-dev
 libmicrohttpd-dev
 libqrencode-dev
-libseccomp-dev
 libsecret-1-dev
 libsodium-dev
 pkg-config
+golang
+libgtk-3-dev
+libwebkit2gtk-4.0-dev

--- a/docker/ubuntu:jammy.dependencies
+++ b/docker/ubuntu:jammy.dependencies
@@ -1,0 +1,1 @@
+ubuntu:focal.dependencies

--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -31,7 +31,7 @@ BuildRequires: help2man >= 1.41
 BuildRequires: libsecret-devel >= 0.18.4
 BuildRequires: desktop-file-utils
 BuildRequires: qrencode-devel >= 3
-BuildRequires: golang >= 1.17
+BuildRequires: golang >= 1.16
 BuildRequires: gtk3-devel
 %if 0%{?suse_version} > 0
 %if 0%{?sle_version} < 150400

--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -104,8 +104,9 @@ Requires: xterm
 Requires: webkit2gtk3
 Requires: gtk3
 %else
-Requires: webkit2gtk3-minibrowser
-Requires: libgtk-3-0
+#Requires: webkit2gtk3-minibrowser
+Requires: webkit2gtk3
+Requires: gtk3
 %endif
 
 

--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -33,7 +33,15 @@ BuildRequires: desktop-file-utils
 BuildRequires: qrencode-devel >= 3
 BuildRequires: golang >= 1.17
 BuildRequires: gtk3-devel
+%if 0%{?suse_version} > 0
+%if 0%{?sle_version} < 150400
 BuildRequires: webkit2gtk3-devel
+%else
+BuildRequires: webkit2gtk3-soup2-devel
+%endif
+%else # all non suse packages:
+BuildRequires: webkit2gtk3-devel
+%endif
 BuildRequires: gcc-c++
 
 Requires: oidc-agent-desktop == %{version}-%{release}
@@ -43,7 +51,6 @@ BuildRoot:	%{_tmppath}/%{name}
 %files
 %defattr(-,root,root,-)
 %doc %{_defaultdocdir}/%{name}-%{version}
-#%doc %{_defaultdocdir}/%{name}-%{version}/README.md
 %license LICENSE
 
 

--- a/rpm/oidc-agent.spec
+++ b/rpm/oidc-agent.spec
@@ -33,15 +33,27 @@ BuildRequires: desktop-file-utils
 BuildRequires: qrencode-devel >= 3
 BuildRequires: golang >= 1.16
 BuildRequires: gtk3-devel
+
+# webkit2gtk3
 %if 0%{?suse_version} > 0
-%if 0%{?sle_version} < 150400
-BuildRequires: webkit2gtk3-devel
-%else
+%if 0%{?sle_version} > 150300
+# 15.4 and larger
 BuildRequires: webkit2gtk3-soup2-devel
-%endif
-%else # all non suse packages:
+%else
+# 15.3 and tumbleweed
+%if 0%{?suse_version} > 1590
+# tumbleweed
+BuildRequires: webkit2gtk3-soup2-devel
+%else
+# 15.3 and lower
 BuildRequires: webkit2gtk3-devel
 %endif
+%endif
+# non suse
+%else
+BuildRequires: webkit2gtk3-devel
+%endif
+
 BuildRequires: gcc-c++
 
 Requires: oidc-agent-desktop == %{version}-%{release}


### PR DESCRIPTION
Update the build process to support the move to 4.3.0:
- remove support for centos, ubuntu bionic-beaver, debian buster, opensuse-leap-15.2
- add support for opensuse-leap-15.4, ubuntu-jammy, rockylinux-8.5