### PR TITLE
Add oscar-cli to list of agent clients

### DIFF
--- a/gitbook/agent-clients.md
+++ b/gitbook/agent-clients.md
@@ -15,3 +15,4 @@ to obtain an access token from oidc-agent. The following applications are alread
 - [CYGNO Library](https://github.com/gmazzitelli/cygno_repo)
 - [EGI Swift Finder](https://github.com/lburgey/egiSwiftFinder)
 - [DODAS-TS/rclone](https://github.com/DODAS-TS/rclone)
+- [OSCAR-CLI](https://github.com/grycap/oscar-cli)


### PR DESCRIPTION
Hi, as we recently integrate the OIDC Agent into [OSCAR-CLI](https://github.com/grycap/oscar-cli) to support authorization via OIDC tokens (by default using EGI Check-in), I open this pull request to add the client in the documentation.

Regards.