### PR TITLE
Create directories explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,7 @@ endif
 ## Compile and generate depencency info
 $(OBJDIR)/$(CLIENT)/$(CLIENT).o : $(APILIB)/$(SHARED_LIB_NAME_FULL)
 $(OBJDIR)/%.o : $(SRCDIR)/%.c
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -c $< -o $@ -DVERSION=\"$(VERSION)\" $(DEFINE_CONFIG_PATH) $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO)
 	@# Create dependency infos
 	@{ \
@@ -432,6 +433,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	@echo "Compiled "$<" successfully!"
 
 $(OBJDIR)/%.o : $(SRCDIR)/%.cc
+	@mkdir -p $(@D)
 	@$(CXX) $(CPPFLAGS) -c $< -o $@ -DVERSION=\"$(VERSION)\" $(DEFINE_CONFIG_PATH)
 	@# Create dependency infos
 	@{ \
@@ -449,15 +451,18 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.cc
 
 ## Compile lib sources
 $(OBJDIR)/%.o : $(LIBDIR)/%.c
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -c $< -o $@
 	@echo "Compiled "$<" successfully!"
 
 ## Compile position independent code
 $(PICOBJDIR)/%.o : $(SRCDIR)/%.c
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -fpic -fvisibility=hidden -c $< -o $@ -DVERSION=\"$(VERSION)\" -DCONFIG_PATH=\"$(CONFIG_AFTER_INST_PATH)\" $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO)
 	@echo "Compiled "$<" with pic successfully!"
 
 $(PICOBJDIR)/%.o : $(LIBDIR)/%.c
+	@mkdir -p $(@D)
 	@$(CC) $(CFLAGS) -fpic -fvisibility=hidden -c $< -o $@
 	@echo "Compiled "$<" with pic successfully!"
 


### PR DESCRIPTION
Building with make -j N for N>1

often resulted in:

```
Fatal error: can't create obj/oidc-agent/agent_state.o: No such file or directory
make: *** [Makefile:395: obj/oidc-agent/agent_state.o] Error 2
make: *** Waiting for unfinished jobs....
Assembler messages:
Fatal error: can't create obj/oidc-agent/daemonize.o: No such file or directory
make: *** [Makefile:395: obj/oidc-agent/daemonize.o] Error 2
Assembler messages:
Fatal error: can't create obj/oidc-agent/http/http.o: No such file or directory
```

especially with newer versions of GNU Make, for instance 4.4

This patch makes the directory creation for object files more explicit. There are other ways to resolve this for sure.