### PR TITLE
Fix heisenbug of windows pipelines not working

### DIFF
--- a/.gitlab-ci-scripts/local-before-script.sh
+++ b/.gitlab-ci-scripts/local-before-script.sh
@@ -89,9 +89,6 @@ esac
 
 # Clean up
 rm -rf delme
-echo "==============================[find]=============================="
-find 
-echo "==============================[find]=============================="
          
 echo "======== oidc-agent-local-before-script done   ========"
 

--- a/.gitlab-ci-scripts/local-before-script.sh
+++ b/.gitlab-ci-scripts/local-before-script.sh
@@ -89,6 +89,9 @@ esac
 
 # Clean up
 rm -rf delme
+echo "==============================[find]=============================="
+find 
+echo "==============================[find]=============================="
          
 echo "======== oidc-agent-local-before-script done   ========"
 

--- a/.gitlab-ci-scripts/local-before-script.sh
+++ b/.gitlab-ci-scripts/local-before-script.sh
@@ -62,6 +62,8 @@ case ${DISTRO} in
             buster)     make buster-debsource                           ;;
         esac
     ;;
+    win) # Do nothing for windows
+    ;;
     *) # We expect only RPM by default
         [ -d rpm ] || {
             echo "using freshly cloned and adapted rpm folder"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,3 +167,4 @@ installer:
     branch: $TRIGGER_BRANCH
     strategy: depend
 
+ 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,4 +167,3 @@ installer:
     branch: $TRIGGER_BRANCH
     strategy: depend
 
- 

--- a/Makefile
+++ b/Makefile
@@ -438,9 +438,6 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
-	ls -la obj/oidc-agent ;\
-	ls -la `dirname $${depFileName}`;\
-	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -440,12 +440,10 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
 	TEST="${MINGW}${MSYS}";\
 	[ -z ${TEST} ] || {\
-		echo "obj-dir: obj/oidc-agent";\
-		ls -la obj/oidc-agent ;\
-		echo "Dirname: `dirname $${depFileName}`";\
-		ls -la `dirname $${depFileName}`;\
+		ls -la obj/oidc-agent > /dev/null ;\
+		ls -la `dirname $${depFileName}` > /dev/null;\
 		echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
-		sleep 1.5;\
+		sleep 2.5;\
 	};\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,8 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
+	echo "obj-dir: obj/oidc-agent";\
+    ls -la obj/oidc-agent ;\
 	echo "Dirname: `dirname $${depFileName}`";\
 	ls -la `dirname $${depFileName}`;\
 	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\

--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,15 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
-	sleep 1.2;\
+	TEST="${MINGW}${MSYS}"
+	[ -z ${TEST} ] || {\
+		echo "obj-dir: obj/oidc-agent";\
+		ls -la obj/oidc-agent ;\
+		echo "Dirname: `dirname $${depFileName}`";\
+		ls -la `dirname $${depFileName}`;\
+		echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
+		sleep 1.5;\
+	}
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	echo "Dirname: `dirname $${depFileName}`";\
 	ls -la `dirname $${depFileName}`;\
 	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
+	sleep 0.2;\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
-	TEST="${MINGW}${MSYS}"
+	TEST="${MINGW}${MSYS}";\
 	[ -z ${TEST} ] || {\
 		echo "obj-dir: obj/oidc-agent";\
 		ls -la obj/oidc-agent ;\
@@ -446,7 +446,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 		ls -la `dirname $${depFileName}`;\
 		echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
 		sleep 1.5;\
-	}\
+	};\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,9 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
+	echo "Dirname: `dirname $${depFileName}`";\
+	ls -la `dirname $${depFileName}`;\
+	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,9 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
+	ls -la obj/oidc-agent ;\
+	ls -la `dirname $${depFileName}`;\
+	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -438,12 +438,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	set -e ;\
 	depFileName=$(OBJDIR)/$*.d ;\
 	$(CC) -MM $(CFLAGS) $< -o $${depFileName} $(DEFINE_USE_CJSON_SO) $(DEFINE_USE_LIST_SO) $(DEFINE_USE_MUSTACHE_SO) ;\
-	echo "obj-dir: obj/oidc-agent";\
-    ls -la obj/oidc-agent ;\
-	echo "Dirname: `dirname $${depFileName}`";\
-	ls -la `dirname $${depFileName}`;\
-	echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
-	sleep 0.2;\
+	sleep 1.2;\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\

--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ $(OBJDIR)/%.o : $(SRCDIR)/%.c
 		ls -la `dirname $${depFileName}`;\
 		echo "mv -f $${depFileName} $${depFileName}.tmp" ;\
 		sleep 1.5;\
-	}
+	}\
 	mv -f $${depFileName} $${depFileName}.tmp ;\
 	sed -e 's|.*:|$@:|' < $${depFileName}.tmp > $${depFileName} ;\
 	cp -f $${depFileName} $${depFileName}.tmp ;\


### PR DESCRIPTION
Fix simply runs an `ls > /dev/null` and a `sleep 2.5`

This is apparently an issue in MSYS and Cygwin itself: <https://github.com/msys2/msys2-runtime/issues/59>
