### PR TITLE
Add shell tool "oidc-tokensh", based on httogensh from htgettoken

### DIFF
--- a/gitbook/oidc-tokensh/general.md
+++ b/gitbook/oidc-tokensh/general.md
@@ -1,0 +1,23 @@
+## General Usage
+
+`oidc-tokensh` is a tool to ensure that valid Access Tokens are always
+available in a location such as `$XDG_RUNTIME_DIR/bt_u$ID`,
+`/tmp/bt_u$ID`, or `$BEARER_TOKEN_FILE` just as specified
+<https://zenodo.org/records/3937438>.
+
+`oidc-tokensh` provides an "almost drop-in replacement" for `httokensh` of
+the [htgettoken](https://github.com/fermitools/htgettoken) tool package.
+
+`oidc-tokensh` starts a new shell through `oidc-agent` and prompts the user
+for the passphrase of the `oidc-agent shortname` that will be loaded.
+
+The user may specify the `shortname` with the `--oidc <shortname>` option.
+If only one `shortname` is configured, this one will be used by default.
+
+```
+Usage: oidc-tokensh [--oidc <shortname>] [-- <command>]
+```
+
+
+See [Detailed Information About All
+Options](options.md) for more information.

--- a/gitbook/oidc-tokensh/options.md
+++ b/gitbook/oidc-tokensh/options.md
@@ -1,0 +1,34 @@
+## Detailed Information About All Options
+
+* [`-h, --help`](#help)
+* [`--oidc <name>|<OP-url>`](#oidc)
+* [`--minsecs <seconds>`](#minsecs)
+* [`-o|--outfile <file>`](#outfile)
+* [`-v|--verbose`](#verbose)
+* [`-- <command>`](#command)
+
+
+### `--oidc`
+
+This option is used to specify the `shortname` of an `oidc-agent`
+configuration. If only one agent configuration is defined, this option may
+be skipped.
+
+### `--minsecs`
+
+Specify the minimum number of seconds that the Access Token should still
+be valid for.
+
+### `--outfile`
+
+Specify alternative file for storing the Access Token.
+
+### `--verbose`
+
+Show debug output
+
+### `-- <command>`
+
+Instead of the default shell, you can specify any other shell-like command
+here. This is useful to specify your favourite shell.
+

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -188,16 +188,16 @@ cleanup()
 }
 #########################################################################
 
-[ -z ${OIDC_ID} ] && { # the --oidc option was not defined. We try to find
+[ -z "${OIDC_ID}" ] && { # the --oidc option was not defined. We try to find
                        # if there is only one configured. If so, we use
                        # that one.
     echo "Trying to auto-detect oidc-agent configuration"
-    NUM_OIDC_ACCOUNTS=$(oidc-add -l | grep -v "The following" | wc -l)
-    [ $NUM_OIDC_ACCOUNTS -eq 1 ] && {
+    NUM_OIDC_ACCOUNTS=$(oidc-add -l | grep -cv "The following")
+    [ "$NUM_OIDC_ACCOUNTS" -eq 1 ] && {
         OIDC_ID=$(oidc-add -l | grep -v "The following")
         echo "Defaulting to $OIDC_ID"
     }
-    [ $NUM_OIDC_ACCOUNTS -eq 1 ] || {
+    [ "$NUM_OIDC_ACCOUNTS" -eq 1 ] || {
         echo "Please specify the oidc-agent shortname that you wish to use"
         exit 3
     }

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -28,10 +28,10 @@ usage()
     echo "command defaults to \$SHELL"
 } >&2
 
-if [ $# = 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-    echo "[${LINENO}] You ran:  $0 $@"
-    usage
-fi
+# if [ $# = 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+#     echo "[${LINENO}] You ran:  $0 $*"
+#     # usage
+# fi
 
 OIDC_TOKEN_ARGS=""
 CMND_ARGS=""
@@ -137,10 +137,6 @@ start_agent(){
         echo "[${LINENO}] starting: >>oidc-agent -- /bin/bash -c "$0 --renewer ${ORIG_ARGS}"<<"
     }
     oidc-agent -- /bin/bash -c "$0 --renewer ${ORIG_ARGS}"
-
-    # old and working:
-    # echo "[${LINENO}] starting: >>oidc-agent -- /bin/bash -c $0 --renewer --oidc egi<<"
-    # oidc-agent -- /bin/bash -c "$0 --renewer --oidc egi"
 }
 
 start_token_renewer() {
@@ -148,8 +144,8 @@ start_token_renewer() {
     gettoken "Initial" 2
     set -m
     {
-        exec 3>&1 1>>$BEARER_TOKEN_FILE.log
-        exec 4>&2 2>>$BEARER_TOKEN_FILE.log
+        exec 3>&1 1>>"$BEARER_TOKEN_FILE.log"
+        exec 4>&2 2>>"$BEARER_TOKEN_FILE.log"
         trap cleanup 0
         # keep a copy of $PPID because it will change to 1 if parent dies
         PARENTPID=$PPID
@@ -183,7 +179,7 @@ start_token_renewer() {
 
 cleanup()
 {
-    if kill -- -$BACKGROUND_PID 2>/dev/null; then
+    if kill -- -"$BACKGROUND_PID" 2>/dev/null; then
         wait 2>/dev/null
         rm -f "${BEARER_TOKEN_FILE}" "${BEARER_TOKEN_FILE}.log"
     else
@@ -191,7 +187,7 @@ cleanup()
         exec 1>&3 3>&-
         exec 2>&4 4>&-
         echo -e "\n\nRenewal background process failed to renew Access Token, see $BEARER_TOKEN_FILE.log\n"
-        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> ${BEARER_TOKEN_FILE}.log
+        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> "${BEARER_TOKEN_FILE}.log"
         exit 2
     fi
 }

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -21,7 +21,6 @@ usage()
     echo "  -o, --outfile         file in which the token will be stored"
     echo
     echo "command defaults to \$SHELL"
-    exit 1
 } >&2
 
 if [ $# = 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -68,7 +67,7 @@ while [ $# -gt 0 ]; do
 done
 
 OIDC_TOKEN_ARGS="${OIDC_ID} -t ${MINSECS}"
-[ "x${GOTVERBOSE}" == "xtrue" ] && {
+[ "${GOTVERBOSE}" == "true" ] && {
     echo "OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
 }
 
@@ -95,32 +94,35 @@ if ${GOTOUTFILE}; then
 fi
 
 decodejwt() {
-    echo $1 | cut -d. -f 2 \
+    echo "$1" | cut -d. -f 2 \
         | base64 -di 2>/dev/null \
         | jq --indent 4 2>/dev/null
 }
 
 gettoken()
 {
-    TOKEN=$(oidc-token ${OIDC_TOKEN_ARGS})
+    TOKEN=$(oidc-token "${OIDC_TOKEN_ARGS}")
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
         echo "oidc-token failed, $1" >&2
         exit $RETVAL
     fi
-    echo ${TOKEN} > ${BEARER_TOKEN_FILE}
+    echo "${TOKEN}" > "${BEARER_TOKEN_FILE}"
 
-    TOKENJSON="$(decodejwt ${TOKEN})"
+    TOKENJSON=$(decodejwt "${TOKEN}")
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
         echo "decodejwt failed, $1" >&2
         exit $RETVAL
     fi
 
-    EXP="$(echo $TOKENJSON|jq .exp)"
-    NOW="$(date +%s)"
-    let SLEEPSECS="$EXP - $MINSECS - $NOW + 2"
-    if [ "$SLEEPSECS" -lt $2 ]; then
+    EXP=$(echo "${TOKENJSON}"|jq .exp)
+    NOW=$(date +%s)
+    # let SLEEPSECS="$EXP - $MINSECS - $NOW + 2"
+    # echo "SLEEPSECS: ${SLEEPSECS}"
+    SLEEPSECS=$((EXP - MINSECS - NOW + 2))
+    echo "SLEEPSECS: ${SLEEPSECS}"
+    if [ "${SLEEPSECS}" -lt "$2" ]; then
         echo "Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
         exit 1
     fi
@@ -138,7 +140,7 @@ echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
 {
     # keep a copy of $PPID because it will change to 1 if parent dies
     PARENTPID=$PPID
-    [ "x${GOTVERBOSE}" == "xtrue" ] && {
+    [ "${GOTVERBOSE}" == "true" ] && {
         echo oidc-token args are "${OIDC_TOKEN_ARGS}"
     }
     while true; do
@@ -153,7 +155,7 @@ echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
             exit 0
         fi
     done
-} >$BEARER_TOKEN_FILE.log 2>&1 &
+} >"${BEARER_TOKEN_FILE}.log" 2>&1 &
 
 BACKGROUND_PID=$!
 
@@ -161,7 +163,7 @@ cleanup()
 {
     if kill -- -$BACKGROUND_PID 2>/dev/null; then
         wait 2>/dev/null
-        rm -f $BEARER_TOKEN_FILE $BEARER_TOKEN_FILE.log
+        rm -f "${BEARER_TOKEN_FILE}" "${BEARER_TOKEN_FILE}.log"
     else
         echo >&2
         echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >&2
@@ -171,8 +173,8 @@ cleanup()
 
 trap cleanup 0
 
-[ "x${GOTVERBOSE}" == "xtrue" ] && {
-    echo "COMMAND: ${COMMANDARGS}"
+[ "${GOTVERBOSE}" == "true" ] && {
+    echo "COMMAND: ${COMMANDARGS[*]}"
 }
 # "${COMMANDARGS[@]}"
 oidc-agent "${COMMANDARGS[@]}"

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -20,7 +20,6 @@ usage()
     echo "  --oidc <name>|<OP-url>  name or url of the oidc-agent "
     echo "                          configuration to use"
     echo "  --minsecs <seconds>     minimum lifetime the token should have"
-    echo "  -o, --outfile           file in which the token will be stored"
     echo "  -o|--outfile <file>     specify alternative file for storing"
     echo "                          the Access Token"
     echo "  -v|--verbose            show debug output"
@@ -174,7 +173,6 @@ start_token_renewer() {
     ${CMND_ARGS}
 
 }
-#########################################################################
 
 cleanup()
 {
@@ -186,6 +184,22 @@ cleanup()
             echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> "${BEARER_TOKEN_FILE}.log"
             exit 2
         fi
+    }
+}
+#########################################################################
+
+[ -z ${OIDC_ID} ] && { # the --oidc option was not defined. We try to find
+                       # if there is only one configured. If so, we use
+                       # that one.
+    echo "Trying to auto-detect oidc-agent configuration"
+    NUM_OIDC_ACCOUNTS=$(oidc-add -l | grep -v "The following" | wc -l)
+    [ $NUM_OIDC_ACCOUNTS -eq 1 ] && {
+        OIDC_ID=$(oidc-add -l | grep -v "The following")
+        echo "Defaulting to $OIDC_ID"
+    }
+    [ $NUM_OIDC_ACCOUNTS -eq 1 ] || {
+        echo "Please specify the oidc-agent shortname that you wish to use"
+        exit 3
     }
 }
 

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -67,19 +67,39 @@ if [ ${#COMMANDARGS[@]} = 0 ]; then
     COMMANDARGS=("$SHELL")
 fi
 
-if [ -z "$BEARER_TOKEN_FILE" ] && ! $GOTOUTFILE; then
-    BTFILE="bt_u$(id -u).sh-$$"
-    if [ -n "$XDG_RUNTIME_DIR" ]; then
-        BEARER_TOKEN_FILE=$XDG_RUNTIME_DIR/$BTFILE
+get_bearer_token_file(){
+    # Get BEARER_TOKEN_FILE according to WLCG Bearer Token Discovery (https://zenodo.org/records/3937438)
+    RETVAL=""
+    if [ -z "${BEARER_TOKEN_FILE}" ]; then
+        if [ -z "$XDG_RUNTIME_DIR" ]; then
+            RETVAL="/tmp/bt_u$(id -u)"
+        else
+            RETVAL="${XDG_RUNTIME_DIR}/bt_u$(id -u)"
+        fi
     else
-        BEARER_TOKEN_FILE=/tmp/$BTFILE
+        RETVAL="${BEARER_TOKEN_FILE}"
     fi
-    export BEARER_TOKEN_FILE
-fi
+    echo "${RETVAL}"
+}
+get_bearer_token_file_orig(){
+    if [ -z "$BEARER_TOKEN_FILE" ] && ! $GOTOUTFILE; then
+        if [ -n "$XDG_RUNTIME_DIR" ]; then
+            BTFILE="bt_u$(id -u).sh-$$"
+            BEARER_TOKEN_FILE=$XDG_RUNTIME_DIR/$BTFILE
+        else
+            BEARER_TOKEN_FILE=/tmp/$BTFILE
+        fi
+        export BEARER_TOKEN_FILE
+    fi
 
-if ${GOTOUTFILE}; then
-    export BEARER_TOKEN_FILE=${OUTFILE}
-fi
+    if ${GOTOUTFILE}; then
+        export BEARER_TOKEN_FILE="${OUTFILE}"
+    fi
+    echo "${BEARER_TOKEN_FILE}"
+}
+
+BEARER_TOKEN_FILE=$(get_bearer_token_file)
+export BEARER_TOKEN_FILE
 
 decodejwt() {
     echo "$1" | cut -d. -f 2 \
@@ -89,7 +109,7 @@ decodejwt() {
 
 gettoken()
 {
-    TOKEN=$(oidc-token "${OIDC_TOKEN_ARGS}")
+    TOKEN=$(oidc-token ${OIDC_TOKEN_ARGS})
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
         echo "oidc-token failed, $1" >&2
@@ -106,10 +126,7 @@ gettoken()
 
     EXP=$(echo "${TOKENJSON}"|jq .exp)
     NOW=$(date +%s)
-    # let SLEEPSECS="$EXP - $MINSECS - $NOW + 2"
-    # echo "SLEEPSECS: ${SLEEPSECS}"
     SLEEPSECS=$((EXP - MINSECS - NOW + 2))
-    echo "SLEEPSECS: ${SLEEPSECS}"
     if [ "${SLEEPSECS}" -lt "$2" ]; then
         echo "Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
         exit 1

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -43,29 +43,12 @@ while [ $# -gt 0 ]; do
         COMMANDARGS+=("$1")
     else
         case "$1" in
-            -h|--help)
-                usage 
-                exit 0
-                ;;
-            --)
-                GOTSEP=true
-                ;;
-            --minsecs)
-                MINSECS=$2
-                shift
-                ;;
-            -v|--verbose)
-                GOTVERBOSE=true
-                ;;
-            -o|--outfile)
-                GOTOUTFILE=true
-                OUTFILE=$2
-                shift
-                ;;
-            --oidc)
-                OIDC_ID=$2 
-                shift
-                ;;
+            -h|--help)          usage;                           exit 0 ;;
+            --)                 GOTSEP=true                             ;;
+            --minsecs)          MINSECS=$2;                      shift  ;;
+            -v|--verbose)       GOTVERBOSE=true                         ;;
+            -o|--outfile)       GOTOUTFILE=true OUTFILE=$2;      shift  ;;
+            --oidc)             OIDC_ID=$2;                      shift  ;;
         esac
     fi
     shift

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -158,7 +158,7 @@ start_token_renewer() {
             sleep $SLEEPSECS
             date
             if kill -0 $PARENTPID 2>/dev/null; then
-                gettoken "exiting" 60
+                gettoken "exiting" 10
             else
                 echo "[${LINENO}] Parent process $PARENTPID not running, exiting"
                 echo "[${LINENO}]         mypid: $$"
@@ -166,30 +166,27 @@ start_token_renewer() {
             fi
         done
     } &
+    export BACKGROUND_PID=$!
     [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
         echo "[${LINENO}] excuting: ${CMND_ARGS}"
     }
     # Start the actual shell
     ${CMND_ARGS}
 
-    echo "$BEARER_TOKEN_FILE.log"
-    export BACKGROUND_PID=$!
 }
 #########################################################################
 
 cleanup()
 {
-    if kill -- -"$BACKGROUND_PID" 2>/dev/null; then
-        wait 2>/dev/null
-        rm -f "${BEARER_TOKEN_FILE}" "${BEARER_TOKEN_FILE}.log"
-    else
-        # echo >&2
-        exec 1>&3 3>&-
-        exec 2>&4 4>&-
-        echo -e "\n\nRenewal background process failed to renew Access Token, see $BEARER_TOKEN_FILE.log\n"
-        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> "${BEARER_TOKEN_FILE}.log"
-        exit 2
-    fi
+    [ -z "${BACKGROUND_PID}" ] || {
+        if kill -0 "$BACKGROUND_PID" 2>/dev/null; then
+            rm -f "${BEARER_TOKEN_FILE}" "${BEARER_TOKEN_FILE}.log"
+        else
+            echo -e "\n\nRenewal background process failed to renew Access Token, see $BEARER_TOKEN_FILE.log\n"
+            echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> "${BEARER_TOKEN_FILE}.log"
+            exit 2
+        fi
+    }
 }
 
 OIDC_TOKEN_ARGS="${OIDC_ID} -t ${MINSECS}"
@@ -217,6 +214,7 @@ export BEARER_TOKEN_FILE
         echo "[${LINENO}] Starting renewer"
         echo "[${LINENO}] OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
     }
+    trap cleanup 0
     start_token_renewer
     [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
         echo "[${LINENO}] BACKGROUND_PID: ${BACKGROUND_PID}"
@@ -225,6 +223,6 @@ export BEARER_TOKEN_FILE
 
 
 [ "${START_RENEWER}" == "false" ] && {
-    trap cleanup 0
+    # trap cleanup 0
     start_agent
 }

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -154,7 +154,6 @@ start_token_renewer() {
             echo "[${LINENO}] oidc-token args are ${OIDC_TOKEN_ARGS}"
         }
         while true; do
-            date
             echo "Renewal scheduled in $SLEEPSECS seconds"
             sleep $SLEEPSECS
             date

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -16,10 +16,15 @@ usage()
     echo "This tool is based on httokensh by Dave Dykstra."
     echo ""
     echo "Options:"
-    echo "  -h, --help            show this help message and exit"
-    echo "  --minsecs <seconds>   minimum lifetime the token should have"
-    echo "  -o, --outfile         file in which the token will be stored"
-    echo
+    echo "  -h, --help              show this help message and exit"
+    echo "  --oidc <name>|<OP-url>  name or url of the oidc-agent "
+    echo "                          configuration to use"
+    echo "  --minsecs <seconds>     minimum lifetime the token should have"
+    echo "  -o, --outfile           file in which the token will be stored"
+    echo "  -o|--outfile <file>     specify alternative file for storing"
+    echo "                          the Access Token"
+    echo "  -v|--verbose            show debug output"
+    echo ""
     echo "command defaults to \$SHELL"
 } >&2
 
@@ -135,7 +140,9 @@ gettoken "not running command" 1
 # enable job control so background processes get their own process group
 set -m
 
-echo "Bearer Token is at $BEARER_TOKEN_FILE"
+[ "${GOTVERBOSE}" == "true" ] && {
+    echo "Bearer Token is at $BEARER_TOKEN_FILE"
+}
 echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
 {
     # keep a copy of $PPID because it will change to 1 if parent dies

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#
+# Run oidc-agent and then start a shell command and keep the access
+# token updated for as long as the command runs.
+#
+# Adapted by Marcus Hardt 2024, based on httokensh by Dave Dykstra
+
+usage()
+{
+    echo "Usage: oidc-tokensh [-h] [oidc-token options] -- [command]"
+    echo 
+    echo "Runs oidc-agent and oidc-token with given options, starts the "
+    echo "command, and runs oidc-token in the background as needed to "
+    echo "renew the token until the command exits."
+    echo ""
+    echo "This tool is based on httokensh by Dave Dykstra."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help            show this help message and exit"
+    echo "  --minsecs <seconds>   minimum lifetime the token should have"
+    echo "  -o, --outfile         file in which the token will be stored"
+    echo
+    echo "command defaults to \$SHELL"
+    exit 1
+} >&2
+
+if [ $# = 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+fi
+
+OIDC_TOKEN_ARGS=""
+COMMANDARGS=()
+GOTSEP=false
+MINSECS=60
+GOTVERBOSE=false
+GOTOUTFILE=false
+while [ $# -gt 0 ]; do
+    if $GOTSEP; then
+        COMMANDARGS+=("$1")
+    else
+        case "$1" in
+            -h|--help)
+                usage 
+                exit 0
+                ;;
+            --)
+                GOTSEP=true
+                ;;
+            --minsecs)
+                MINSECS=$2
+                shift
+                ;;
+            -v|--verbose)
+                GOTVERBOSE=true
+                ;;
+            -o|--outfile)
+                GOTOUTFILE=true
+                OUTFILE=$2
+                shift
+                ;;
+            --oidc)
+                OIDC_ID=$2 
+                shift
+                ;;
+        esac
+    fi
+    shift
+done
+
+OIDC_TOKEN_ARGS="${OIDC_ID} -t ${MINSECS}"
+[ "x${GOTVERBOSE}" == "xtrue" ] && {
+    echo "OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
+}
+
+if ! $GOTSEP; then
+    COMMANDARGS=("$SHELL")
+fi
+
+if [ ${#COMMANDARGS[@]} = 0 ]; then
+    COMMANDARGS=("$SHELL")
+fi
+
+if [ -z "$BEARER_TOKEN_FILE" ] && ! $GOTOUTFILE; then
+    BTFILE="bt_u$(id -u).sh-$$"
+    if [ -n "$XDG_RUNTIME_DIR" ]; then
+        BEARER_TOKEN_FILE=$XDG_RUNTIME_DIR/$BTFILE
+    else
+        BEARER_TOKEN_FILE=/tmp/$BTFILE
+    fi
+    export BEARER_TOKEN_FILE
+fi
+
+if ${GOTOUTFILE}; then
+    export BEARER_TOKEN_FILE=${OUTFILE}
+fi
+
+decodejwt() {
+    echo $1 | cut -d. -f 2 \
+        | base64 -di 2>/dev/null \
+        | jq --indent 4 2>/dev/null
+}
+
+gettoken()
+{
+    TOKEN=$(oidc-token ${OIDC_TOKEN_ARGS})
+    RETVAL="$?"
+    if [ $RETVAL != 0 ]; then
+        echo "oidc-token failed, $1" >&2
+        exit $RETVAL
+    fi
+    echo ${TOKEN} > ${BEARER_TOKEN_FILE}
+
+    TOKENJSON="$(decodejwt ${TOKEN})"
+    RETVAL="$?"
+    if [ $RETVAL != 0 ]; then
+        echo "decodejwt failed, $1" >&2
+        exit $RETVAL
+    fi
+
+    EXP="$(echo $TOKENJSON|jq .exp)"
+    NOW="$(date +%s)"
+    let SLEEPSECS="$EXP - $MINSECS - $NOW + 2"
+    if [ "$SLEEPSECS" -lt $2 ]; then
+        echo "Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
+        exit 1
+    fi
+}
+
+# The first time it is possible to get a cached token that is barely
+# beyond the minsecs, so reduce the minimum to just 1 second
+gettoken "not running command" 1
+
+# enable job control so background processes get their own process group
+set -m
+
+echo "Bearer Token is at $BEARER_TOKEN_FILE"
+echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
+{
+    # keep a copy of $PPID because it will change to 1 if parent dies
+    PARENTPID=$PPID
+    [ "x${GOTVERBOSE}" == "xtrue" ] && {
+        echo oidc-token args are "${OIDC_TOKEN_ARGS}"
+    }
+    while true; do
+        date
+        echo "Renewal scheduled in $SLEEPSECS seconds"
+        sleep $SLEEPSECS
+        date
+        if kill -0 $PARENTPID; then
+            gettoken "exiting" 60
+        else
+            echo "Parent process $PARENTPID not running, exiting"
+            exit 0
+        fi
+    done
+} >$BEARER_TOKEN_FILE.log 2>&1 &
+
+BACKGROUND_PID=$!
+
+cleanup()
+{
+    if kill -- -$BACKGROUND_PID 2>/dev/null; then
+        wait 2>/dev/null
+        rm -f $BEARER_TOKEN_FILE $BEARER_TOKEN_FILE.log
+    else
+        echo >&2
+        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >&2
+        exit 1
+    fi
+}
+
+trap cleanup 0
+
+[ "x${GOTVERBOSE}" == "xtrue" ] && {
+    echo "COMMAND: ${COMMANDARGS}"
+}
+# "${COMMANDARGS[@]}"
+oidc-agent "${COMMANDARGS[@]}"

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -98,17 +98,18 @@ decodejwt() {
         | jq --indent 4 2>/dev/null
 }
 
-gettoken()
-{
+gettoken() {
+    MESSAGE="$1"
+    TIME_PARAM="$2"
     [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
         echo "[${LINENO}] running oidc-add ${OIDC_TOKEN_ARGS}"
     }
-    oidc-add ${OIDC_TOKEN_ARGS}
+    oidc-add ${OIDC_TOKEN_ARGS} >/dev/null
     TOKEN=$(oidc-token ${OIDC_TOKEN_ARGS})
     # TOKEN=$(oidc-token egi)
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
-        echo "[${LINENO}] oidc-token failed, $1" >&2
+        echo "[${LINENO}] oidc-token failed, ${MESSAGE}" >&2
         exit $RETVAL
     fi
     echo "${TOKEN}" > "${BEARER_TOKEN_FILE}"
@@ -116,23 +117,23 @@ gettoken()
     TOKENJSON=$(decodejwt "${TOKEN}")
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
-        echo "[${LINENO}] decodejwt failed, $1" >&2
+        echo "[${LINENO}] decodejwt failed, ${MESSAGE}" >&2
         exit $RETVAL
     fi
 
     EXP=$(echo "${TOKENJSON}"|jq .exp)
     NOW=$(date +%s)
-    SLEEPSECS=$((EXP - MINSECS - NOW + 2))
+    SLEEPSECS=$((EXP - MINSECS - NOW + TIME_PARAM))
     [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
-        echo "[${LINENO}] SLEEPSECS: ${SLEEPSECS} -- \$2: $2"
+        echo "[${LINENO}] SLEEPSECS: ${SLEEPSECS} -- TIME_PARAM: ${TIME_PARAM}"
     }
-    if [ "${SLEEPSECS}" -lt "$2" ]; then
-        echo "[${LINENO}] Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
+    if [ "${SLEEPSECS}" -lt "${TIME_PARAM}" ]; then
+        echo "[${LINENO}] Calculated renewal time of $SLEEPSECS seconds is less than ${TIME_PARAM}, ${MESSAGE}"
         exit 1
     fi
 }
 
-start_agent(){
+start_agent() {
     [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
         echo "[${LINENO}] starting: >>oidc-agent -- /bin/bash -c "$0 --renewer ${ORIG_ARGS}"<<"
     }
@@ -141,7 +142,7 @@ start_agent(){
 
 start_token_renewer() {
     # enable job control so background processes get their own process group
-    gettoken "Initial" 2
+    gettoken "Initial" 20
     set -m
     {
         exec 3>&1 1>>"$BEARER_TOKEN_FILE.log"
@@ -158,7 +159,7 @@ start_token_renewer() {
             sleep $SLEEPSECS
             date
             if kill -0 $PARENTPID 2>/dev/null; then
-                gettoken "exiting" 10
+                gettoken "Regular" 60
             else
                 echo "[${LINENO}] Parent process $PARENTPID not running, exiting"
                 echo "[${LINENO}]         mypid: $$"

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -98,9 +98,6 @@ get_bearer_token_file_orig(){
     echo "${BEARER_TOKEN_FILE}"
 }
 
-BEARER_TOKEN_FILE=$(get_bearer_token_file)
-export BEARER_TOKEN_FILE
-
 decodejwt() {
     echo "$1" | cut -d. -f 2 \
         | base64 -di 2>/dev/null \
@@ -132,6 +129,9 @@ gettoken()
         exit 1
     fi
 }
+
+BEARER_TOKEN_FILE=$(get_bearer_token_file)
+export BEARER_TOKEN_FILE
 
 # The first time it is possible to get a cached token that is barely
 # beyond the minsecs, so reduce the minimum to just 1 second

--- a/src/oidc-tokensh/oidc-tokensh
+++ b/src/oidc-tokensh/oidc-tokensh
@@ -7,13 +7,13 @@
 
 usage()
 {
+    echo "This tool is based on httokensh by Dave Dykstra."
+    echo ""
     echo "Usage: oidc-tokensh [-h] [oidc-token options] -- [command]"
     echo 
     echo "Runs oidc-agent and oidc-token with given options, starts the "
     echo "command, and runs oidc-token in the background as needed to "
     echo "renew the token until the command exits."
-    echo ""
-    echo "This tool is based on httokensh by Dave Dykstra."
     echo ""
     echo "Options:"
     echo "  -h, --help              show this help message and exit"
@@ -29,44 +29,38 @@ usage()
 } >&2
 
 if [ $# = 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo "[${LINENO}] You ran:  $0 $@"
     usage
 fi
 
 OIDC_TOKEN_ARGS=""
-COMMANDARGS=()
+CMND_ARGS=""
+ORIG_ARGS=""
 GOTSEP=false
 MINSECS=60
 GOTVERBOSE=false
 GOTOUTFILE=false
+START_RENEWER=false
+
 while [ $# -gt 0 ]; do
+    ORIG_ARGS="${ORIG_ARGS} ${1}"
     if $GOTSEP; then
-        COMMANDARGS+=("$1")
+        CMND_ARGS="${CMND_ARGS} ${1}"
     else
         case "$1" in
             -h|--help)          usage;                           exit 0 ;;
             --)                 GOTSEP=true                             ;;
-            --minsecs)          MINSECS=$2;                      shift  ;;
             -v|--verbose)       GOTVERBOSE=true                         ;;
-            -o|--outfile)       GOTOUTFILE=true OUTFILE=$2;      shift  ;;
-            --oidc)             OIDC_ID=$2;                      shift  ;;
+            --minsecs)          MINSECS=$2;                      ORIG_ARGS="${ORIG_ARGS} $2"; shift  ;;
+            -o|--outfile)       GOTOUTFILE=true OUTFILE=$2;      ORIG_ARGS="${ORIG_ARGS} $2"; shift  ;;
+            --oidc)             OIDC_ID=$2;                      ORIG_ARGS="${ORIG_ARGS} $2"; shift  ;;
+            --renewer)          START_RENEWER=true                      ;;
         esac
     fi
     shift
 done
 
-OIDC_TOKEN_ARGS="${OIDC_ID} -t ${MINSECS}"
-[ "${GOTVERBOSE}" == "true" ] && {
-    echo "OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
-}
-
-if ! $GOTSEP; then
-    COMMANDARGS=("$SHELL")
-fi
-
-if [ ${#COMMANDARGS[@]} = 0 ]; then
-    COMMANDARGS=("$SHELL")
-fi
-
+#########################################################################
 get_bearer_token_file(){
     # Get BEARER_TOKEN_FILE according to WLCG Bearer Token Discovery (https://zenodo.org/records/3937438)
     RETVAL=""
@@ -95,7 +89,7 @@ get_bearer_token_file_orig(){
     if ${GOTOUTFILE}; then
         export BEARER_TOKEN_FILE="${OUTFILE}"
     fi
-    echo "${BEARER_TOKEN_FILE}"
+    echo "[${LINENO}] ${BEARER_TOKEN_FILE}"
 }
 
 decodejwt() {
@@ -106,10 +100,15 @@ decodejwt() {
 
 gettoken()
 {
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] running oidc-add ${OIDC_TOKEN_ARGS}"
+    }
+    oidc-add ${OIDC_TOKEN_ARGS}
     TOKEN=$(oidc-token ${OIDC_TOKEN_ARGS})
+    # TOKEN=$(oidc-token egi)
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
-        echo "oidc-token failed, $1" >&2
+        echo "[${LINENO}] oidc-token failed, $1" >&2
         exit $RETVAL
     fi
     echo "${TOKEN}" > "${BEARER_TOKEN_FILE}"
@@ -117,54 +116,70 @@ gettoken()
     TOKENJSON=$(decodejwt "${TOKEN}")
     RETVAL="$?"
     if [ $RETVAL != 0 ]; then
-        echo "decodejwt failed, $1" >&2
+        echo "[${LINENO}] decodejwt failed, $1" >&2
         exit $RETVAL
     fi
 
     EXP=$(echo "${TOKENJSON}"|jq .exp)
     NOW=$(date +%s)
     SLEEPSECS=$((EXP - MINSECS - NOW + 2))
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] SLEEPSECS: ${SLEEPSECS} -- \$2: $2"
+    }
     if [ "${SLEEPSECS}" -lt "$2" ]; then
-        echo "Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
+        echo "[${LINENO}] Calculated renewal time of $SLEEPSECS seconds is less than $2, $1"
         exit 1
     fi
 }
 
-BEARER_TOKEN_FILE=$(get_bearer_token_file)
-export BEARER_TOKEN_FILE
-
-# The first time it is possible to get a cached token that is barely
-# beyond the minsecs, so reduce the minimum to just 1 second
-gettoken "not running command" 1
-
-# enable job control so background processes get their own process group
-set -m
-
-[ "${GOTVERBOSE}" == "true" ] && {
-    echo "Bearer Token is at $BEARER_TOKEN_FILE"
-}
-echo "Renewal log is at \$BEARER_TOKEN_FILE.log"
-{
-    # keep a copy of $PPID because it will change to 1 if parent dies
-    PARENTPID=$PPID
-    [ "${GOTVERBOSE}" == "true" ] && {
-        echo oidc-token args are "${OIDC_TOKEN_ARGS}"
+start_agent(){
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] starting: >>oidc-agent -- /bin/bash -c "$0 --renewer ${ORIG_ARGS}"<<"
     }
-    while true; do
-        date
-        echo "Renewal scheduled in $SLEEPSECS seconds"
-        sleep $SLEEPSECS
-        date
-        if kill -0 $PARENTPID; then
-            gettoken "exiting" 60
-        else
-            echo "Parent process $PARENTPID not running, exiting"
-            exit 0
-        fi
-    done
-} >"${BEARER_TOKEN_FILE}.log" 2>&1 &
+    oidc-agent -- /bin/bash -c "$0 --renewer ${ORIG_ARGS}"
 
-BACKGROUND_PID=$!
+    # old and working:
+    # echo "[${LINENO}] starting: >>oidc-agent -- /bin/bash -c $0 --renewer --oidc egi<<"
+    # oidc-agent -- /bin/bash -c "$0 --renewer --oidc egi"
+}
+
+start_token_renewer() {
+    # enable job control so background processes get their own process group
+    gettoken "Initial" 2
+    set -m
+    {
+        exec 3>&1 1>>$BEARER_TOKEN_FILE.log
+        exec 4>&2 2>>$BEARER_TOKEN_FILE.log
+        trap cleanup 0
+        # keep a copy of $PPID because it will change to 1 if parent dies
+        PARENTPID=$PPID
+        [ "${GOTVERBOSE}" == "true" ] && {
+            echo "[${LINENO}] oidc-token args are ${OIDC_TOKEN_ARGS}"
+        }
+        while true; do
+            date
+            echo "Renewal scheduled in $SLEEPSECS seconds"
+            sleep $SLEEPSECS
+            date
+            if kill -0 $PARENTPID 2>/dev/null; then
+                gettoken "exiting" 60
+            else
+                echo "[${LINENO}] Parent process $PARENTPID not running, exiting"
+                echo "[${LINENO}]         mypid: $$"
+                exit 0
+            fi
+        done
+    } &
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] excuting: ${CMND_ARGS}"
+    }
+    # Start the actual shell
+    ${CMND_ARGS}
+
+    echo "$BEARER_TOKEN_FILE.log"
+    export BACKGROUND_PID=$!
+}
+#########################################################################
 
 cleanup()
 {
@@ -172,16 +187,48 @@ cleanup()
         wait 2>/dev/null
         rm -f "${BEARER_TOKEN_FILE}" "${BEARER_TOKEN_FILE}.log"
     else
-        echo >&2
-        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >&2
-        exit 1
+        # echo >&2
+        exec 1>&3 3>&-
+        exec 2>&4 4>&-
+        echo -e "\n\nRenewal background process failed to renew Access Token, see $BEARER_TOKEN_FILE.log\n"
+        echo "Renewal background process failed, see $BEARER_TOKEN_FILE.log" >> ${BEARER_TOKEN_FILE}.log
+        exit 2
     fi
 }
 
-trap cleanup 0
-
-[ "${GOTVERBOSE}" == "true" ] && {
-    echo "COMMAND: ${COMMANDARGS[*]}"
+OIDC_TOKEN_ARGS="${OIDC_ID} -t ${MINSECS}"
+[ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+    echo "[${LINENO}] OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
 }
-# "${COMMANDARGS[@]}"
-oidc-agent "${COMMANDARGS[@]}"
+
+if ! $GOTSEP; then
+    CMND_ARGS="${SHELL}"
+fi
+
+BEARER_TOKEN_FILE=$(get_bearer_token_file)
+export BEARER_TOKEN_FILE
+
+
+[ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+    echo "[${LINENO}] Bearer Token is at $BEARER_TOKEN_FILE"
+}
+[ "${START_RENEWER}" == "false" ] && {
+    echo "Renewal log is at $BEARER_TOKEN_FILE.log"
+}
+
+[ "${START_RENEWER}" == "true" ] && {
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] Starting renewer"
+        echo "[${LINENO}] OIDC_TOKEN_ARGS: ${OIDC_TOKEN_ARGS}"
+    }
+    start_token_renewer
+    [ "${GOTVERBOSE}" == "true" ] && [ "${START_RENEWER}" == "false" ] && {
+        echo "[${LINENO}] BACKGROUND_PID: ${BACKGROUND_PID}"
+    }
+}
+
+
+[ "${START_RENEWER}" == "false" ] && {
+    trap cleanup 0
+    start_agent
+}


### PR DESCRIPTION
This is still under review for people that know what to expect from `httokensh`. 
This one is supposed be a drop-in-replacement, however here one has to provide
the shortname configured in `oidc-agent`