### PR TITLE
use default sock path if $OIDC_SOCK not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This did not work as intended. We made the following changes:
 ### Enhancements
 
 - `oidc-add` can now also take an issuer url to load the default account for this issuer, i.e. `oidc-add <issuer_url>`
+- If no socket path is set a default path is tried. The default path
+  is `$TMPDIR/oidc-agent-service-$UID/oidc-agent.sock`, this is the path used by `oidc-agent-service`
 
 ### Bugfixes
 

--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -13,6 +13,8 @@
 
 #include "utils/oidc_error.h"
 
+char* defaultSocketPath();
+
 #ifndef MINGW
 oidc_error_t initConnectionWithoutPath(struct connection*, int, int);
 oidc_error_t initConnectionWithPath(struct connection*, const char*);

--- a/src/oidc-gen/gen_handler.c
+++ b/src/oidc-gen/gen_handler.c
@@ -19,6 +19,7 @@
 #include "defines/oidc_values.h"
 #include "defines/settings.h"
 #include "ipc/cryptCommunicator.h"
+#include "ipc/ipc.h"
 #include "oidc-agent/oidc/device_code.h"
 #include "oidc-gen/device_code.h"
 #include "oidc-gen/gen_consenter.h"
@@ -321,7 +322,8 @@ void handleCodeExchange(const struct arguments* arguments) {
 #ifdef __MSYS__
     socket_path = getRegistryValue(OIDC_SOCK_ENV_NAME);
 #else
-    socket_path = oidc_strcopy(getenv(OIDC_SOCK_ENV_NAME));
+    socket_path =
+        oidc_strcopy(getenv(OIDC_SOCK_ENV_NAME)) ?: defaultSocketPath();
 #endif
     if (socket_path == NULL) {
       printError("Socket path not encoded in url state and not available from "


### PR DESCRIPTION
This enhancement was implemented after several wishes from a single person @marcvs 