### PR TITLE
Makefile: fix install permissions for static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -755,7 +755,7 @@ $(INCLUDE_PATH)/oidc-agent/oidc_error.h: $(SRCDIR)/utils/oidc_error.h $(INCLUDE_
 	@install -p -m 644 $< $@
 
 $(LIBDEV_PATH)/liboidc-agent.a: $(APILIB)/liboidc-agent.a $(LIBDEV_PATH)
-	@install -p $< $@
+	@install -p -m 644 $< $@
 
 endif
 


### PR DESCRIPTION
Credits go to @mkszuba for fixing this downstream:
https://github.com/gentoo/gentoo/commit/f8f0e712d9e454f4b2dc8e10bcee7795cfab6bc5