### PR TITLE
oidc-agent-service: fix passing of oidc-agent options

### DIFF
--- a/src/oidc-agent-service/oidc-agent-service
+++ b/src/oidc-agent-service/oidc-agent-service
@@ -34,7 +34,7 @@ function echo_vars() {
 }
 
 function start() {
-  json=$(${OIDC_AGENT} -a "${SOCK}" "${OIDC_AGENT_OPTS}" --pid-file="${PID_FILE}" --json)
+  json=$(${OIDC_AGENT} -a "${SOCK}" ${OIDC_AGENT_OPTS} --pid-file="${PID_FILE}" --json)
   OIDCD_PID=$(${ECHO} "${json}" | "${JQ}" -r ".dpid")
   echo_vars
 }


### PR DESCRIPTION
Options are kept in a string separated by whitespace, and would be forced to be a single option when quoting that string again.

fixes #593