### PR TITLE
issuerConfig: do not segfault if there is no user-specific issuer config

### DIFF
--- a/src/utils/config/issuerConfig.c
+++ b/src/utils/config/issuerConfig.c
@@ -271,7 +271,7 @@ static char* updateIssuerConfigFileFormat(char* content) {
 
 static void readIssuerConfigs() {
   char* content = readOidcFile(ISSUER_CONFIG_FILENAME);
-  if (!isJSONArray(content)) {  // old config file
+  if (content && !isJSONArray(content)) {  // old config file
     content = updateIssuerConfigFileFormat(content);
   }
   collectJSONIssuers(content);


### PR DESCRIPTION
If no issuer.config is present in the config directory, content would be nullptr, and trigger a segmentation fault in updateIssuerConfigFileFormat. If there is no local configuration, there is nothing to update, so skip that.

Before this fix, versions >= 5.2.0 would segfault unless `~/.config/oidc-agent/issuer.config` was present, i.e. all fresh installations are affected. 
As a quick hack, affected users can run:
```
mkdir -p ~/.config/oidc-agent
echo '{}' > ~/.config/oidc-agent/issuer.config
```
