### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -21,7 +21,7 @@ oidc_error_t initConnectionWithPath(struct connection*, const char*);
 #endif
 oidc_error_t ipc_client_init(struct connection*, unsigned char);
 
-int ipc_connect(struct connection con);
+oidc_error_t ipc_connect(struct connection con);
 
 char* ipc_read(const SOCKET _sock);
 #ifndef MINGW

--- a/src/oidc-agent/http/http_handler.c
+++ b/src/oidc-agent/http/http_handler.c
@@ -12,8 +12,9 @@
 #include "utils/string/oidc_string.h"
 #include "utils/string/stringUtils.h"
 
-static size_t write_callback(void* ptr, size_t size, size_t nmemb,
-                             struct string* s) {
+static size_t write_callback(char* ptr, size_t size, size_t nmemb,
+                             void* str) {
+  struct string* s = str;
   size_t new_len = s->len + size * nmemb;
   void*  tmp     = secRealloc(s->ptr, new_len + 1);
   if (tmp == NULL) {
@@ -28,10 +29,10 @@ static size_t write_callback(void* ptr, size_t size, size_t nmemb,
 }
 
 #ifndef AGENT_CURL_CONNECT_TIMEOUT
-#define AGENT_CURL_CONNECT_TIMEOUT 5
+#define AGENT_CURL_CONNECT_TIMEOUT 5L
 #endif
 #ifndef AGENT_CURL_TIMEOUT
-#define AGENT_CURL_TIMEOUT 10
+#define AGENT_CURL_TIMEOUT 10L
 #endif
 
 static unsigned char mem_init = 0;


### PR DESCRIPTION
Fix different return type in .h and .c file:
```
src/ipc/ipc.c:176:14: warning: conflicting types for ‘ipc_connect’ due to enum/integer mismatch; have ‘oidc_error_t(struct connection)’ {aka ‘enum _oidc_error(struct connection)’} [-Wenum-int-mismatch]
  176 | oidc_error_t ipc_connect(struct connection con) {
      |              ^~~~~~~~~~~
In file included from src/ipc/ipc.c:2:
src/ipc/ipc.h:24:5: note: previous declaration of ‘ipc_connect’ with type ‘int(struct connection)’
   24 | int ipc_connect(struct connection con);
      |     ^~~~~~~~~~~
```
Fix warnings about wrong argument types when calling curl_easy_setopt
```
src/oidc-agent/http/http_handler.c: In function ‘init’:
src/oidc-agent/http/http_handler.c:69:3: warning: call to ‘_curl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
   69 |   curl_easy_setopt(curl, CURLOPT_TIMEOUT, AGENT_CURL_TIMEOUT);
      |   ^
src/oidc-agent/http/http_handler.c:70:3: warning: call to ‘_curl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
   70 |   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, AGENT_CURL_CONNECT_TIMEOUT);
      |   ^
src/oidc-agent/http/http_handler.c: In function ‘setWriteFunction’:
src/oidc-agent/http/http_handler.c:103:3: warning: call to ‘_curl_easy_setopt_err_write_callback’ declared with attribute warning: curl_easy_setopt expects a curl_write_callback argument [-Wattribute-warning]
  103 |   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
      |   ^
```
