### PR TITLE
fix socket path trust check failing on root-owned directories; improv…

### DIFF
--- a/src/ipc/serveripc.c
+++ b/src/ipc/serveripc.c
@@ -213,6 +213,8 @@ oidc_error_t ipc_server_init(struct connection* con, const char* group_name,
 
 #ifndef ANY_MSYS
   if (check_socket_path(oidc_ipc_dir, group_name) != OIDC_SUCCESS) {
+    agent_log(ERROR, "Socket path trust check failed for directory '%s'",
+              oidc_ipc_dir);
     return oidc_errno;
   }
 #endif
@@ -259,6 +261,8 @@ int ipc_bindAndListen(struct connection* con, const char* group) {
   }
 #ifndef ANY_MSYS
   if (check_socket_path(con->server->sun_path, group) != OIDC_SUCCESS) {
+    agent_log(ERROR, "Socket path trust check failed for '%s'",
+              con->server->sun_path);
     return oidc_errno;
   }
 #endif

--- a/src/utils/file_io/safefile/check_file_path.c
+++ b/src/utils/file_io/safefile/check_file_path.c
@@ -5,7 +5,9 @@
 
 #include "safe_id_range_list.h"
 #include "safe_is_path_trusted.h"
+#include "utils/memory.h"
 #include "utils/oidc_error.h"
+#include "utils/string/stringUtils.h"
 
 oidc_error_t check_socket_path(const char* path, const char* group) {
   struct safe_id_range_list ulist, glist;
@@ -28,6 +30,12 @@ oidc_error_t check_socket_path(const char* path, const char* group) {
     return oidc_errno;
   }
   if (safe_add_id_to_list(&glist, (id_t)getgid())) {
+    safe_destroy_id_range_list(&ulist);
+    safe_destroy_id_range_list(&glist);
+    oidc_errno = OIDC_EMEM;
+    return oidc_errno;
+  }
+  if (safe_add_id_to_list(&glist, (id_t)0)) {
     safe_destroy_id_range_list(&ulist);
     safe_destroy_id_range_list(&glist);
     oidc_errno = OIDC_EMEM;
@@ -60,10 +68,17 @@ oidc_error_t check_socket_path(const char* path, const char* group) {
     case SAFE_PATH_TRUSTED_CONFIDENTIAL:
       oidc_errno = OIDC_SUCCESS;
       break; /* GOOD */
-    case SAFE_PATH_UNTRUSTED:
+    case SAFE_PATH_UNTRUSTED: {
       /* Perms are wrong */
       oidc_errno = OIDC_EPERM;
+      char* err  = oidc_sprintf(
+           "socket path location '%s' is not trustworthy: check ownership "
+            "and permissions of all components of the socket path",
+           path);
+      oidc_seterror(err);
+      secFree(err);
       break; /* perm error */
+    }
     case SAFE_PATH_TRUSTED:
     case SAFE_PATH_TRUSTED_STICKY_DIR:
       /* TRUSTED-only is fine */

--- a/src/utils/oidc_error.c
+++ b/src/utils/oidc_error.c
@@ -45,7 +45,7 @@ char* oidc_serrorFor(oidc_error_t err) {
     case OIDC_EALLOC: return "memory alloc failed";
     case OIDC_EMEM: return "system out of memory";
     case OIDC_EEOF: return "empty file";
-    case OIDC_EPERM: return "socket path location is not trustworthy";
+    case OIDC_EPERM: return oidc_error;
     case OIDC_EFOPEN: return "could not open file";
     case OIDC_EFREAD: return "could not read file";
     case OIDC_EWRITE: return "could not write";


### PR DESCRIPTION
…e error message

Add GID 0 (root group) to the trusted GID list, mirroring the existing implicit trust of UID 0. This fixes the issue where directories like /tmp owned by root:root with group-writable + sticky bit permissions were incorrectly flagged as untrusted. Fixes #603.

Also make the OIDC_EPERM error message include the actual path that failed the trust check, giving users actionable diagnostic information instead of just 'socket path location is not trustworthy'.